### PR TITLE
Update Homebrew formula for v0.3.3

### DIFF
--- a/Formula/tooltrust-scanner.rb
+++ b/Formula/tooltrust-scanner.rb
@@ -9,9 +9,9 @@
 class TooltrustScanner < Formula
   desc "Security scanner for AI agent tool definitions"
   homepage "https://github.com/AgentSafe-AI/tooltrust-scanner"
-  version "0.2.3"
+  version "0.3.3"
   url "https://github.com/AgentSafe-AI/tooltrust-scanner/archive/refs/tags/v#{version}.tar.gz"
-  sha256 "b328a421ce9be9f47c729779055d949bf06b7ac7f6e9b41af3cc15951a0ef197"
+  sha256 "132b246bc101d3c4f71d782f5ecbaeaab5c9560d836548d916284f6afcf12083"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
Updates `Formula/tooltrust-scanner.rb` for release `v0.3.3`.

- bumps the formula version
- refreshes the source tarball SHA256