### PR TITLE
Update Homebrew formula for v0.3.8

### DIFF
--- a/Formula/tooltrust-scanner.rb
+++ b/Formula/tooltrust-scanner.rb
@@ -9,9 +9,9 @@
 class TooltrustScanner < Formula
   desc "Security scanner for AI agent tool definitions"
   homepage "https://github.com/AgentSafe-AI/tooltrust-scanner"
-  version "0.3.6"
+  version "0.3.8"
   url "https://github.com/AgentSafe-AI/tooltrust-scanner/archive/refs/tags/v#{version}.tar.gz"
-  sha256 "53a34f92d33a21d99ca33f0ece6ded5f7363bda1008c80cc8489695600910b87"
+  sha256 "1a48e9acf4e7d3e66f6a526b28e439f5aab455ba6e5e4ed9f51248513bf3392e"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
Updates `Formula/tooltrust-scanner.rb` for release `v0.3.8`.

- bumps the formula version
- refreshes the source tarball SHA256