### PR TITLE
[codex] fail closed on unsafe live scans and restore scanner fidelity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,16 +36,26 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Download ToolTrust Scanner
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ github.action_path }}/go.mod
+        cache-dependency-path: ${{ github.action_path }}/go.sum
+
+    - name: Build ToolTrust Scanner
       shell: bash
       run: |
-        OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-        ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
-        URL="https://github.com/AgentSafe-AI/tooltrust-scanner/releases/latest/download/tooltrust-scanner_${OS}_${ARCH}"
+        BIN="$GITHUB_WORKSPACE/.tooltrust/bin/tooltrust"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          BIN="${BIN}.exe"
+        fi
+
         mkdir -p "$GITHUB_WORKSPACE/.tooltrust/bin"
-        curl -fsSL "$URL" -o "$GITHUB_WORKSPACE/.tooltrust/bin/tooltrust"
-        chmod +x "$GITHUB_WORKSPACE/.tooltrust/bin/tooltrust"
-        echo "$GITHUB_WORKSPACE/.tooltrust/bin" >> $GITHUB_PATH
+        pushd "$GITHUB_ACTION_PATH" >/dev/null
+        go build -trimpath -o "$BIN" ./cmd/tooltrust-scanner
+        popd >/dev/null
+        chmod +x "$BIN"
+        echo "$GITHUB_WORKSPACE/.tooltrust/bin" >> "$GITHUB_PATH"
 
     - name: Run ToolTrust Scanner
       id: scan
@@ -67,7 +77,7 @@ runs:
         fi
 
         if [ -n "${{ inputs.server }}" ]; then
-          tooltrust scan --server "${{ inputs.server }}" --fail-on "${{ inputs.fail-on }}" $DEEP_SCAN_FLAG --output json --file "$REPORT_FILE" >/dev/null
+          tooltrust scan --server "${{ inputs.server }}" --allow-unsafe-live-scan --fail-on "${{ inputs.fail-on }}" $DEEP_SCAN_FLAG --output json --file "$REPORT_FILE" >/dev/null
         elif [ -n "${{ inputs.input }}" ]; then
           tooltrust scan --input "${{ inputs.input }}" --fail-on "${{ inputs.fail-on }}" $DEEP_SCAN_FLAG --output json --file "$REPORT_FILE" >/dev/null
         else

--- a/cmd/tooltrust-mcp/main.go
+++ b/cmd/tooltrust-mcp/main.go
@@ -22,6 +22,7 @@ import (
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/AgentSafe-AI/tooltrust-scanner/internal/userhome"
 	localmcp "github.com/AgentSafe-AI/tooltrust-scanner/pkg/adapter/mcp"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/analyzer"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/gateway"
@@ -523,7 +524,7 @@ func loadMCPConfig() (string, mcpConfig, error) {
 	}
 
 	// 2. Check ~/.claude.json.
-	home, err := os.UserHomeDir()
+	home, err := userhome.Resolve()
 	if err == nil {
 		claudePath := filepath.Join(home, ".claude.json")
 		if data, err := os.ReadFile(claudePath); err == nil { // #nosec G304 -- path is ~/.claude.json, not user-controlled

--- a/cmd/tooltrust-mcp/main.go
+++ b/cmd/tooltrust-mcp/main.go
@@ -700,6 +700,12 @@ func renderTextReport(result *ScanResult) string {
 		if len(p.Destinations) > 0 {
 			lines = append(lines, fmt.Sprintf("  Destination: %s", strings.Join(p.Destinations, "; ")))
 		}
+		if p.DependencyVisibility != "" {
+			lines = append(lines, fmt.Sprintf("  Dependency visibility: %s", p.DependencyVisibility))
+			if p.DependencyNote != "" {
+				lines = append(lines, fmt.Sprintf("  Dependency note: %s", p.DependencyNote))
+			}
+		}
 		for _, issue := range p.Score.Issues {
 			lines = append(lines, fmt.Sprintf("  [%s] %s: %s",
 				issue.RuleID, issue.Severity, humanizeIssue(issue)))
@@ -836,6 +842,7 @@ func processToolsRaw(ctx context.Context, tools []model.UnifiedTool) (*ScanResul
 			return nil, fmt.Errorf("policy evaluation failed for tool %q: %v", tools[i].Name, evalErr)
 		}
 		policy.Behavior, policy.Destinations = analyzer.SummarizeToolContext(tools[i])
+		policy.DependencyVisibility, policy.DependencyNote = analyzer.DependencyVisibilityForTool(tools[i])
 		policies = append(policies, policy)
 
 		switch policy.Action {

--- a/cmd/tooltrust-mcp/main.go
+++ b/cmd/tooltrust-mcp/main.go
@@ -35,6 +35,8 @@ var version = "dev"
 // scanTimeout is the maximum time allowed for a single server scan.
 const scanTimeout = 60 * time.Second
 
+const allowUnsafeLiveScanArg = "allow_unsafe_live_scan"
+
 func main() {
 	help := flag.Bool("help", false, "Show usage information")
 	flag.BoolVar(help, "h", false, "Show usage information")
@@ -167,6 +169,10 @@ func buildScanServerTool() mcplib.Tool {
 			mcplib.Required(),
 			mcplib.Description(`The exact command used to start the MCP server via stdio. Example: "npx -y @modelcontextprotocol/server-memory"`),
 		),
+		mcplib.WithBoolean(
+			allowUnsafeLiveScanArg,
+			mcplib.Description("Set to true to acknowledge that this launches the target process on the host before ToolTrust can score it."),
+		),
 	)
 }
 
@@ -174,6 +180,9 @@ func handleScanServer(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.
 	command, ok := req.GetArguments()["command"].(string)
 	if !ok || command == "" {
 		return mcplib.NewToolResultError("command argument is required and must be a non-empty string"), nil
+	}
+	if !allowUnsafeLiveScan(req) {
+		return mcplib.NewToolResultError(unsafeLiveScanOptInMessage("tooltrust_scan_server")), nil
 	}
 
 	args, err := shellquote.Split(command)
@@ -191,6 +200,15 @@ func handleScanServer(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.
 	}
 
 	return processTools(ctx, tools)
+}
+
+func allowUnsafeLiveScan(req mcplib.CallToolRequest) bool {
+	value, ok := req.GetArguments()[allowUnsafeLiveScanArg].(bool)
+	return ok && value
+}
+
+func unsafeLiveScanOptInMessage(toolName string) string {
+	return fmt.Sprintf("%s refuses to launch MCP servers without %s=true because the target process runs on the host before ToolTrust can score it", toolName, allowUnsafeLiveScanArg)
 }
 
 // scanLiveServer spawns an MCP server, connects via stdio, lists its tools,
@@ -377,10 +395,14 @@ func buildScanConfigTool() mcplib.Tool {
 				"Returns a summary report with scan results for each server. Servers that fail to start "+
 				"are reported with an error note; scanning continues for remaining servers.",
 		),
+		mcplib.WithBoolean(
+			allowUnsafeLiveScanArg,
+			mcplib.Description("Set to true to acknowledge that configured MCP servers are launched on the host before ToolTrust can score them."),
+		),
 	)
 }
 
-func handleScanConfig(ctx context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+func handleScanConfig(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	configPath, cfg, err := loadMCPConfig()
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
@@ -388,6 +410,9 @@ func handleScanConfig(ctx context.Context, _ mcplib.CallToolRequest) (*mcplib.Ca
 
 	if len(cfg.MCPServers) == 0 {
 		return mcplib.NewToolResultText(fmt.Sprintf("No MCP servers configured in %s.", configPath)), nil
+	}
+	if !allowUnsafeLiveScan(req) {
+		return mcplib.NewToolResultError(unsafeLiveScanOptInMessage("tooltrust_scan_config")), nil
 	}
 
 	// Scan all servers in parallel.

--- a/cmd/tooltrust-mcp/main_test.go
+++ b/cmd/tooltrust-mcp/main_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kballard/go-shellquote"
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -202,7 +203,10 @@ func TestHandleScanServer_MissingArgument(t *testing.T) {
 
 func TestHandleScanServer_InvalidCommand(t *testing.T) {
 	req := mcplib.CallToolRequest{}
-	req.Params.Arguments = map[string]any{"command": "/nonexistent/command/that/does/not/exist"}
+	req.Params.Arguments = map[string]any{
+		"command":                "/nonexistent/command/that/does/not/exist",
+		"allow_unsafe_live_scan": true,
+	}
 
 	result, err := handleScanServer(context.Background(), req)
 	require.NoError(t, err)
@@ -210,6 +214,40 @@ func TestHandleScanServer_InvalidCommand(t *testing.T) {
 	assert.False(t, result.IsError) // returned as text, not error
 	text := result.Content[0].(mcplib.TextContent).Text
 	assert.Contains(t, text, "Failed to scan live server")
+}
+
+// ── unsafe live scan opt-in tests ───────────────────────────────────────────
+
+func TestHandleScanServer_RequiresUnsafeOptInBeforeExecutingCommand(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "executed")
+	t.Setenv("TOOLTRUST_HELPER_UNSAFE_LIVE_SCAN", "1")
+	t.Setenv("TOOLTRUST_HELPER_MARKER", marker)
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"command": shellquote.Join(os.Args[0], "-test.run=TestHelperUnsafeLiveScanProcess"),
+	}
+
+	result, err := handleScanServer(context.Background(), req)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(marker)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "command should not execute without explicit unsafe live scan opt-in")
+
+	require.True(t, result.IsError)
+	text := result.Content[0].(mcplib.TextContent).Text
+	assert.Contains(t, text, "allow_unsafe_live_scan")
+}
+
+func TestHelperUnsafeLiveScanProcess(t *testing.T) {
+	if os.Getenv("TOOLTRUST_HELPER_UNSAFE_LIVE_SCAN") != "1" {
+		return
+	}
+	marker := os.Getenv("TOOLTRUST_HELPER_MARKER")
+	if marker != "" {
+		_ = os.WriteFile(marker, []byte("executed"), 0o644)
+	}
+	os.Exit(0)
 }
 
 // ── tooltrust_lookup tests ──────────────────────────────────────────────────
@@ -376,6 +414,47 @@ func TestHandleScanConfig_NoConfigFile(t *testing.T) {
 }
 
 // ── Self-scan skip tests ────────────────────────────────────────────────────
+
+func TestHandleScanConfig_RequiresUnsafeOptInBeforeExecutingConfiguredServers(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "executed")
+	helperPath := filepath.Join(dir, "unsafe-helper.exe")
+	helperBinary, err := os.ReadFile(os.Args[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(helperPath, helperBinary, 0o755))
+
+	cfg := mcpConfig{
+		MCPServers: map[string]mcpServerEntry{
+			"side-effect-server": {
+				Command: helperPath,
+				Args:    []string{"-test.run=TestHelperUnsafeLiveScanProcess"},
+				Env: map[string]string{
+					"TOOLTRUST_HELPER_UNSAFE_LIVE_SCAN": "1",
+					"TOOLTRUST_HELPER_MARKER":           marker,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mcp.json"), data, 0o644))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(origDir) //nolint:errcheck // best-effort restore in test cleanup
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+
+	result, err := handleScanConfig(context.Background(), req)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(marker)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "configured command should not execute without explicit unsafe live scan opt-in")
+	require.True(t, result.IsError)
+	text := result.Content[0].(mcplib.TextContent).Text
+	assert.Contains(t, text, "allow_unsafe_live_scan")
+}
 
 func TestIsSelfEntry_ByName(t *testing.T) {
 	assert.True(t, isSelfEntry("tooltrust", mcpServerEntry{Command: "node", Args: []string{"server.js"}}))

--- a/cmd/tooltrust-mcp/main_test.go
+++ b/cmd/tooltrust-mcp/main_test.go
@@ -160,6 +160,30 @@ func TestRenderTextReport_IncludesBehaviorAndDestinationContext(t *testing.T) {
 	assert.Contains(t, text, "Destination: dynamic email recipient (bcc); hardcoded domain: api.postmarkapp.com")
 }
 
+func TestRenderTextReport_IncludesDependencyVisibilityForFlaggedTools(t *testing.T) {
+	result := &ScanResult{
+		Summary: ScanSummary{
+			Total:    1,
+			Allowed:  0,
+			Approval: 1,
+			Blocked:  0,
+		},
+		Policies: []model.GatewayPolicy{
+			{
+				ToolName:             "fetch_url",
+				Action:               model.ActionRequireApproval,
+				DependencyVisibility: "No dependency data",
+				DependencyNote:       "No metadata.dependencies or repo_url were exposed by this MCP server.",
+				Score:                model.RiskScore{Grade: model.GradeC},
+			},
+		},
+	}
+
+	text := renderTextReport(result)
+	assert.Contains(t, text, "Dependency visibility: No dependency data")
+	assert.Contains(t, text, "Dependency note: No metadata.dependencies or repo_url were exposed by this MCP server.")
+}
+
 func TestProcessToolsRaw_PopulatesBehaviorAndDestinationContext(t *testing.T) {
 	tools := []model.UnifiedTool{
 		{
@@ -179,6 +203,22 @@ func TestProcessToolsRaw_PopulatesBehaviorAndDestinationContext(t *testing.T) {
 	require.Len(t, result.Policies, 1)
 	assert.Equal(t, []string{"uses_network"}, result.Policies[0].Behavior)
 	assert.Equal(t, []string{"dynamic URL input (url)"}, result.Policies[0].Destinations)
+}
+
+func TestProcessToolsRaw_PopulatesDependencyVisibility(t *testing.T) {
+	tools := []model.UnifiedTool{
+		{
+			Name:        "plain_mcp",
+			Protocol:    model.ProtocolMCP,
+			Description: "Plain tool.",
+		},
+	}
+
+	result, err := processToolsRaw(context.Background(), tools)
+	require.NoError(t, err)
+	require.Len(t, result.Policies, 1)
+	assert.Equal(t, "No dependency data", result.Policies[0].DependencyVisibility)
+	assert.Equal(t, "No metadata.dependencies or repo_url were exposed by this MCP server.", result.Policies[0].DependencyNote)
 }
 
 // ── tooltrust_scan_server tests ─────────────────────────────────────────────

--- a/cmd/tooltrust-scanner/gate.go
+++ b/cmd/tooltrust-scanner/gate.go
@@ -29,7 +29,6 @@ type gateOpts struct {
 	scope       string
 	deepScan    bool
 	rulesDir    string
-	allowUnsafeLiveScan bool
 }
 
 // blockedError signals that installation was blocked by grade policy (exit 1).
@@ -43,6 +42,7 @@ func (e *blockedError) Error() string {
 
 func newGateCmd() *cobra.Command {
 	var opts gateOpts
+	var allowUnsafeLiveScan bool
 
 	cmd := &cobra.Command{
 		Use:   "gate <package> [-- extra-args...]",
@@ -68,7 +68,7 @@ the grade threshold.
 				opts.extraArgs = args[dashIdx:]
 			}
 
-			err := runGate(cmd.Context(), opts)
+			err := runGate(cmd.Context(), opts, allowUnsafeLiveScan)
 			if err != nil {
 				if _, ok := err.(*blockedError); ok {
 					// Exit 1 for policy block
@@ -90,18 +90,18 @@ the grade threshold.
 	cmd.Flags().StringVar(&opts.scope, "scope", "project", "config scope: project (writes .mcp.json) or user (writes ~/.claude.json)")
 	cmd.Flags().BoolVar(&opts.deepScan, "deep-scan", false, "enable AI-based semantic analysis (pass-through to scanner)")
 	cmd.Flags().StringVar(&opts.rulesDir, "rules-dir", "", "custom YAML rules directory (pass-through to scanner)")
-	cmd.Flags().BoolVar(&opts.allowUnsafeLiveScan, "allow-unsafe-live-scan", false, "acknowledge that gate executes the package on the host before ToolTrust can score it")
+	cmd.Flags().BoolVar(&allowUnsafeLiveScan, "allow-unsafe-live-scan", false, "acknowledge that gate executes the package on the host before ToolTrust can score it")
 
 	return cmd
 }
 
-func runGate(ctx context.Context, opts gateOpts) error {
+func runGate(ctx context.Context, opts gateOpts, allowUnsafeLiveScan bool) error {
 	// Derive server name.
 	serverName := opts.name
 	if serverName == "" {
 		serverName = deriveServerName(opts.packageName)
 	}
-	if !opts.allowUnsafeLiveScan {
+	if !allowUnsafeLiveScan {
 		return fmt.Errorf("gate refuses to execute %q without --allow-unsafe-live-scan because the target package runs on the host before ToolTrust can score it", opts.packageName)
 	}
 

--- a/cmd/tooltrust-scanner/gate.go
+++ b/cmd/tooltrust-scanner/gate.go
@@ -13,21 +13,23 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
+	"github.com/AgentSafe-AI/tooltrust-scanner/internal/userhome"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/analyzer"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/gateway"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
 
 type gateOpts struct {
-	packageName string
-	extraArgs   []string
-	name        string
-	force       bool
-	dryRun      bool
-	blockOn     string
-	scope       string
-	deepScan    bool
-	rulesDir    string
+	packageName         string
+	extraArgs           []string
+	name                string
+	force               bool
+	dryRun              bool
+	blockOn             string
+	scope               string
+	deepScan            bool
+	rulesDir            string
+	allowUnsafeLiveScan bool
 }
 
 // blockedError signals that installation was blocked by grade policy (exit 1).
@@ -52,11 +54,11 @@ the grade threshold.
   Grade A/B → auto-install
   Grade C/D → prompt for confirmation
   Grade F   → block installation`,
-		Example: `  tooltrust-scanner gate @modelcontextprotocol/server-memory -- /tmp
-  tooltrust-scanner gate --dry-run @modelcontextprotocol/server-filesystem -- /tmp
-  tooltrust-scanner gate --name my-server @some/package
-  tooltrust-scanner gate --block-on D @some/package
-  tooltrust-scanner gate --scope user @some/package`,
+		Example: `  tooltrust-scanner gate --allow-unsafe-live-scan @modelcontextprotocol/server-memory -- /tmp
+  tooltrust-scanner gate --allow-unsafe-live-scan --dry-run @modelcontextprotocol/server-filesystem -- /tmp
+  tooltrust-scanner gate --allow-unsafe-live-scan --name my-server @some/package
+  tooltrust-scanner gate --allow-unsafe-live-scan --block-on D @some/package
+  tooltrust-scanner gate --allow-unsafe-live-scan --scope user @some/package`,
 		Args:               cobra.MinimumNArgs(1),
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,6 +90,7 @@ the grade threshold.
 	cmd.Flags().StringVar(&opts.scope, "scope", "project", "config scope: project (writes .mcp.json) or user (writes ~/.claude.json)")
 	cmd.Flags().BoolVar(&opts.deepScan, "deep-scan", false, "enable AI-based semantic analysis (pass-through to scanner)")
 	cmd.Flags().StringVar(&opts.rulesDir, "rules-dir", "", "custom YAML rules directory (pass-through to scanner)")
+	cmd.Flags().BoolVar(&opts.allowUnsafeLiveScan, "allow-unsafe-live-scan", false, "acknowledge that gate executes the package on the host before ToolTrust can score it")
 
 	return cmd
 }
@@ -98,9 +101,12 @@ func runGate(ctx context.Context, opts gateOpts) error {
 	if serverName == "" {
 		serverName = deriveServerName(opts.packageName)
 	}
+	if !opts.allowUnsafeLiveScan {
+		return fmt.Errorf("gate refuses to execute %q without --allow-unsafe-live-scan because the target package runs on the host before ToolTrust can score it", opts.packageName)
+	}
 
-	// Build the npx command string for scanning.
-	serverCmd := buildServerCommand(opts.packageName, opts.extraArgs)
+	serverArgs := buildServerArgs(opts.packageName, opts.extraArgs)
+	serverCmd := formatCommand(serverArgs)
 
 	pterm.Info.Printfln("Scanning server: %s", serverCmd)
 	pterm.Info.Printfln("Server name: %s", serverName)
@@ -110,7 +116,7 @@ func runGate(ctx context.Context, opts gateOpts) error {
 	liveCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	tools, err := scanLiveServer(liveCtx, serverCmd)
+	tools, err := scanLiveServerArgs(liveCtx, serverArgs, serverCmd)
 	if err != nil {
 		return fmt.Errorf("live server scan failed: %w", err)
 	}
@@ -204,11 +210,14 @@ func deriveServerName(packageName string) string {
 	return packageName
 }
 
+func buildServerArgs(packageName string, extraArgs []string) []string {
+	parts := []string{"npx", "-y", packageName}
+	return append(parts, extraArgs...)
+}
+
 // buildServerCommand builds the npx command string for running the server.
 func buildServerCommand(packageName string, extraArgs []string) string {
-	parts := []string{"npx", "-y", packageName}
-	parts = append(parts, extraArgs...)
-	return strings.Join(parts, " ")
+	return formatCommand(buildServerArgs(packageName, extraArgs))
 }
 
 // parseGrade converts a grade string to a model.Grade.
@@ -379,7 +388,7 @@ func resolveConfigPath(scope string) (string, error) {
 	case "project":
 		return ".mcp.json", nil
 	case "user":
-		home, err := os.UserHomeDir()
+		home, err := userhome.Resolve()
 		if err != nil {
 			return "", fmt.Errorf("failed to determine home directory: %w", err)
 		}

--- a/cmd/tooltrust-scanner/gate.go
+++ b/cmd/tooltrust-scanner/gate.go
@@ -139,7 +139,7 @@ func runGate(ctx context.Context, opts gateOpts, allowUnsafeLiveScan bool) error
 			return fmt.Errorf("gateway evaluation failed for tool %q: %w", tools[i].Name, evalErr)
 		}
 		policy.Behavior, policy.Destinations = analyzer.SummarizeToolContext(tools[i])
-		policy.DependencyVisibility, policy.DependencyNote = dependencyVisibilityForTool(tools[i])
+		policy.DependencyVisibility, policy.DependencyNote = analyzer.DependencyVisibilityForTool(tools[i])
 		policies = append(policies, policy)
 	}
 

--- a/cmd/tooltrust-scanner/gate.go
+++ b/cmd/tooltrust-scanner/gate.go
@@ -20,15 +20,15 @@ import (
 )
 
 type gateOpts struct {
-	packageName         string
-	extraArgs           []string
-	name                string
-	force               bool
-	dryRun              bool
-	blockOn             string
-	scope               string
-	deepScan            bool
-	rulesDir            string
+	packageName string
+	extraArgs   []string
+	name        string
+	force       bool
+	dryRun      bool
+	blockOn     string
+	scope       string
+	deepScan    bool
+	rulesDir    string
 	allowUnsafeLiveScan bool
 }
 

--- a/cmd/tooltrust-scanner/gate_test.go
+++ b/cmd/tooltrust-scanner/gate_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
@@ -73,6 +75,19 @@ func TestGateDecision_Force_Bypasses(t *testing.T) {
 	got := gateDecision(model.GradeF, model.GradeF, true)
 	if !got {
 		t.Error("expected --force to bypass grade F block")
+	}
+}
+
+func TestRunGate_RequiresUnsafeLiveScanOptIn(t *testing.T) {
+	err := runGate(context.Background(), gateOpts{
+		packageName: "@modelcontextprotocol/server-memory",
+		dryRun:      true,
+	})
+	if err == nil {
+		t.Fatal("expected gate to refuse unsafe live scan without opt-in")
+	}
+	if !strings.Contains(err.Error(), "--allow-unsafe-live-scan") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/tooltrust-scanner/gate_test.go
+++ b/cmd/tooltrust-scanner/gate_test.go
@@ -82,7 +82,7 @@ func TestRunGate_RequiresUnsafeLiveScanOptIn(t *testing.T) {
 	err := runGate(context.Background(), gateOpts{
 		packageName: "@modelcontextprotocol/server-memory",
 		dryRun:      true,
-	})
+	}, false)
 	if err == nil {
 		t.Fatal("expected gate to refuse unsafe live scan without opt-in")
 	}

--- a/cmd/tooltrust-scanner/live.go
+++ b/cmd/tooltrust-scanner/live.go
@@ -452,7 +452,7 @@ func parseRequirementsFile(path string) ([]nodeDependency, error) {
 			line = strings.TrimSpace(line[:i])
 		}
 		if i := strings.Index(line, "=="); i > 0 {
-			name := strings.TrimSpace(line[:i])
+			name := normalizePythonRequirementName(strings.TrimSpace(line[:i]))
 			version := strings.TrimSpace(line[i+2:])
 			if name != "" && version != "" {
 				deps = append(deps, nodeDependency{Name: name, Version: version, Ecosystem: "PyPI", Source: "local_lockfile"})
@@ -463,6 +463,13 @@ func parseRequirementsFile(path string) ([]nodeDependency, error) {
 		return nil, fmt.Errorf("scan requirements.txt %s: %w", path, err)
 	}
 	return deps, nil
+}
+
+func normalizePythonRequirementName(name string) string {
+	if idx := strings.IndexByte(name, '['); idx >= 0 {
+		name = name[:idx]
+	}
+	return strings.TrimSpace(name)
 }
 
 func parsePNPMLockfile(path string) ([]nodeDependency, error) {

--- a/cmd/tooltrust-scanner/live.go
+++ b/cmd/tooltrust-scanner/live.go
@@ -21,6 +21,14 @@ import (
 )
 
 func scanLiveServer(ctx context.Context, serverCmd string) ([]model.UnifiedTool, error) {
+	args, err := parseServerCommand(serverCmd)
+	if err != nil {
+		return nil, err
+	}
+	return scanLiveServerArgs(ctx, args, serverCmd)
+}
+
+func parseServerCommand(serverCmd string) ([]string, error) {
 	args, err := shellquote.Split(serverCmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse server command: %w", err)
@@ -28,11 +36,22 @@ func scanLiveServer(ctx context.Context, serverCmd string) ([]model.UnifiedTool,
 	if len(args) == 0 {
 		return nil, fmt.Errorf("empty server command")
 	}
+	return args, nil
+}
 
-	importTransport := true
-	_ = importTransport // To avoid unused variable issue during plan stage if I mess up imports
+func formatCommand(args []string) string {
+	return shellquote.Join(args...)
+}
 
-	spinner, err := pterm.DefaultSpinner.Start("🔌 Connecting to live MCP server: " + serverCmd)
+func scanLiveServerArgs(ctx context.Context, args []string, displayCmd string) ([]model.UnifiedTool, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("empty server command")
+	}
+	if strings.TrimSpace(displayCmd) == "" {
+		displayCmd = formatCommand(args)
+	}
+
+	spinner, err := pterm.DefaultSpinner.Start("🔌 Connecting to live MCP server: " + displayCmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start spinner: %w", err)
 	}
@@ -313,9 +332,6 @@ func parseNodeLockfile(path string) ([]nodeDependency, error) {
 
 func detectLocalProjectRoot(args []string) string {
 	candidates := []string{}
-	if cwd, err := os.Getwd(); err == nil {
-		candidates = append(candidates, cwd)
-	}
 	for _, arg := range args {
 		if arg == "" || strings.HasPrefix(arg, "-") {
 			continue
@@ -490,40 +506,73 @@ func parseYarnLockfile(path string) ([]nodeDependency, error) {
 		if line == "" || strings.HasPrefix(line, "#") || !strings.HasSuffix(line, ":") {
 			continue
 		}
-		if strings.Contains(line, " version ") {
+		header := strings.TrimSuffix(line, ":")
+		if header == "__metadata" || strings.Contains(line, " version ") {
 			continue
 		}
+		version := ""
 		for j := i + 1; j < len(lines); j++ {
+			if !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t") {
+				break
+			}
 			next := strings.TrimSpace(lines[j])
 			if next == "" {
 				break
 			}
-			if strings.HasPrefix(next, "version ") {
-				version := strings.Trim(next[len("version "):], "\"")
-				specs := strings.Split(strings.TrimSuffix(line, ":"), ",")
-				for _, spec := range specs {
-					spec = strings.Trim(strings.TrimSpace(spec), "\"")
-					if spec == "" {
-						continue
-					}
-					idx := strings.LastIndex(spec, "@")
-					if idx <= 0 {
-						continue
-					}
-					name := spec[:idx]
-					k := name + "@" + version
-					if seen[k] {
-						continue
-					}
-					seen[k] = true
-					deps = append(deps, nodeDependency{Name: name, Version: version, Ecosystem: "npm", Source: "local_lockfile"})
-				}
-				break
+			switch {
+			case strings.HasPrefix(next, "version "):
+				version = strings.Trim(strings.TrimSpace(next[len("version "):]), "\"'")
+			case strings.HasPrefix(next, "version:"):
+				version = strings.Trim(strings.TrimSpace(next[len("version:"):]), "\"'")
 			}
-			if !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t") {
+			if version != "" {
 				break
 			}
 		}
+		if version == "" {
+			continue
+		}
+		specs := strings.Split(header, ",")
+		for _, spec := range specs {
+			spec = strings.Trim(strings.TrimSpace(spec), "\"'")
+			if spec == "" {
+				continue
+			}
+			name, ok := parseYarnPackageName(spec)
+			if !ok {
+				continue
+			}
+			k := name + "@" + version
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			deps = append(deps, nodeDependency{Name: name, Version: version, Ecosystem: "npm", Source: "local_lockfile"})
+		}
 	}
 	return deps, nil
+}
+
+func parseYarnPackageName(spec string) (string, bool) {
+	spec = strings.TrimSpace(strings.Trim(spec, "\"'"))
+	if spec == "" {
+		return "", false
+	}
+	if strings.HasPrefix(spec, "@") {
+		slash := strings.Index(spec, "/")
+		if slash < 0 {
+			return "", false
+		}
+		rest := spec[slash+1:]
+		at := strings.Index(rest, "@")
+		if at < 0 {
+			return "", false
+		}
+		return spec[:slash+1+at], true
+	}
+	at := strings.Index(spec, "@")
+	if at <= 0 {
+		return "", false
+	}
+	return spec[:at], true
 }

--- a/cmd/tooltrust-scanner/live.go
+++ b/cmd/tooltrust-scanner/live.go
@@ -451,18 +451,29 @@ func parseRequirementsFile(path string) ([]nodeDependency, error) {
 		if i := strings.IndexByte(line, ';'); i >= 0 {
 			line = strings.TrimSpace(line[:i])
 		}
-		if i := strings.Index(line, "=="); i > 0 {
-			name := normalizePythonRequirementName(strings.TrimSpace(line[:i]))
-			version := strings.TrimSpace(line[i+2:])
-			if name != "" && version != "" {
-				deps = append(deps, nodeDependency{Name: name, Version: version, Ecosystem: "PyPI", Source: "local_lockfile"})
-			}
+		name, version, ok := splitPythonRequirementExactPin(line)
+		if ok {
+			deps = append(deps, nodeDependency{Name: name, Version: version, Ecosystem: "PyPI", Source: "local_lockfile"})
 		}
 	}
 	if err := sc.Err(); err != nil {
 		return nil, fmt.Errorf("scan requirements.txt %s: %w", path, err)
 	}
 	return deps, nil
+}
+
+func splitPythonRequirementExactPin(line string) (name, version string, ok bool) {
+	if idx := strings.Index(line, "==="); idx > 0 {
+		name = normalizePythonRequirementName(strings.TrimSpace(line[:idx]))
+		version = strings.TrimSpace(line[idx+3:])
+		return name, version, name != "" && version != ""
+	}
+	if idx := strings.Index(line, "=="); idx > 0 {
+		name = normalizePythonRequirementName(strings.TrimSpace(line[:idx]))
+		version = strings.TrimSpace(line[idx+2:])
+		return name, version, name != "" && version != ""
+	}
+	return "", "", false
 }
 
 func normalizePythonRequirementName(name string) string {

--- a/cmd/tooltrust-scanner/live.go
+++ b/cmd/tooltrust-scanner/live.go
@@ -465,15 +465,23 @@ func parseRequirementsFile(path string) ([]nodeDependency, error) {
 func splitPythonRequirementExactPin(line string) (name, version string, ok bool) {
 	if idx := strings.Index(line, "==="); idx > 0 {
 		name = normalizePythonRequirementName(strings.TrimSpace(line[:idx]))
-		version = strings.TrimSpace(line[idx+3:])
+		version = normalizePythonRequirementVersion(line[idx+3:])
 		return name, version, name != "" && version != ""
 	}
 	if idx := strings.Index(line, "=="); idx > 0 {
 		name = normalizePythonRequirementName(strings.TrimSpace(line[:idx]))
-		version = strings.TrimSpace(line[idx+2:])
+		version = normalizePythonRequirementVersion(line[idx+2:])
 		return name, version, name != "" && version != ""
 	}
 	return "", "", false
+}
+
+func normalizePythonRequirementVersion(version string) string {
+	fields := strings.Fields(strings.TrimSpace(version))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.TrimSuffix(fields[0], "\\")
 }
 
 func normalizePythonRequirementName(name string) string {

--- a/cmd/tooltrust-scanner/live.go
+++ b/cmd/tooltrust-scanner/live.go
@@ -445,6 +445,12 @@ func parseRequirementsFile(path string) ([]nodeDependency, error) {
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
 			continue
 		}
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		if i := strings.IndexByte(line, ';'); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
 		if i := strings.Index(line, "=="); i > 0 {
 			name := strings.TrimSpace(line[:i])
 			version := strings.TrimSpace(line[i+2:])
@@ -469,20 +475,13 @@ func parsePNPMLockfile(path string) ([]nodeDependency, error) {
 	var deps []nodeDependency
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "/") && !strings.HasPrefix(trimmed, "'/") {
+		if !strings.HasPrefix(trimmed, "/") && !strings.HasPrefix(trimmed, "'/") && !strings.HasPrefix(trimmed, "\"/") {
 			continue
 		}
-		trimmed = strings.Trim(trimmed, "'")
-		trimmed = strings.TrimSuffix(trimmed, ":")
-		trimmed = strings.TrimPrefix(trimmed, "/")
-		if trimmed == "" {
+		name, version, ok := parsePNPMLockKey(trimmed)
+		if !ok {
 			continue
 		}
-		idx := strings.LastIndex(trimmed, "@")
-		if idx <= 0 || idx == len(trimmed)-1 {
-			continue
-		}
-		name, version := trimmed[:idx], trimmed[idx+1:]
 		k := name + "@" + version
 		if seen[k] {
 			continue
@@ -491,6 +490,24 @@ func parsePNPMLockfile(path string) ([]nodeDependency, error) {
 		deps = append(deps, nodeDependency{Name: name, Version: version, Ecosystem: "npm", Source: "local_lockfile"})
 	}
 	return deps, nil
+}
+
+func parsePNPMLockKey(key string) (name, version string, ok bool) {
+	trimmed := strings.TrimSpace(key)
+	trimmed = strings.Trim(trimmed, "'\"")
+	trimmed = strings.TrimSuffix(trimmed, ":")
+	trimmed = strings.TrimPrefix(trimmed, "/")
+	if trimmed == "" {
+		return "", "", false
+	}
+	if idx := strings.Index(trimmed, "("); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+	idx := strings.LastIndex(trimmed, "@")
+	if idx <= 0 || idx == len(trimmed)-1 {
+		return "", "", false
+	}
+	return trimmed[:idx], trimmed[idx+1:], true
 }
 
 func parseYarnLockfile(path string) ([]nodeDependency, error) {

--- a/cmd/tooltrust-scanner/main.go
+++ b/cmd/tooltrust-scanner/main.go
@@ -35,7 +35,7 @@ func newRootCmd() *cobra.Command {
 			"data exfiltration, privilege escalation, and supply-chain attacks. " +
 			"Each tool gets a trust grade (A–F) and a gateway policy (ALLOW / REQUIRE_APPROVAL / BLOCK).\n\n" +
 			"Quick start:\n" +
-			"  tooltrust-scanner scan --server \"npx -y @modelcontextprotocol/server-filesystem /tmp\"\n\n" +
+			"  tooltrust-scanner scan --server \"npx -y @modelcontextprotocol/server-filesystem /tmp\" --allow-unsafe-live-scan\n\n" +
 			"Learn more: https://github.com/AgentSafe-AI/tooltrust-scanner",
 	}
 	root.AddCommand(newVersionCmd())
@@ -83,16 +83,17 @@ var severityWeight = map[model.Severity]int{
 
 func newScanCmd() *cobra.Command {
 	var (
-		inputFile  string
-		serverCmd  string
-		protocol   string
-		output     string
-		outputFile string
-		failOn     string
-		dbPath     string
-		verbose    bool
-		deepScan   bool
-		rulesDir   string
+		inputFile           string
+		serverCmd           string
+		protocol            string
+		output              string
+		outputFile          string
+		failOn              string
+		dbPath              string
+		verbose             bool
+		deepScan            bool
+		rulesDir            string
+		allowUnsafeLiveScan bool
 	)
 
 	cmd := &cobra.Command{
@@ -102,19 +103,21 @@ func newScanCmd() *cobra.Command {
   tooltrust-scanner scan --input tools.json --output json
   tooltrust-scanner scan --input tools.json --output json --file report.json
   tooltrust-scanner scan --input tools.json --fail-on block
+  tooltrust-scanner scan --server "npx -y @modelcontextprotocol/server-filesystem /tmp" --allow-unsafe-live-scan
   tooltrust-scanner scan --input tools.json --db scans.db`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runScan(cmd.Context(), scanOpts{
-				inputFile:  inputFile,
-				serverCmd:  serverCmd,
-				protocol:   protocol,
-				output:     output,
-				outputFile: outputFile,
-				failOn:     failOn,
-				dbPath:     dbPath,
-				verbose:    verbose,
-				deepScan:   deepScan,
-				rulesDir:   rulesDir,
+				inputFile:           inputFile,
+				serverCmd:           serverCmd,
+				protocol:            protocol,
+				output:              output,
+				outputFile:          outputFile,
+				failOn:              failOn,
+				dbPath:              dbPath,
+				verbose:             verbose,
+				deepScan:            deepScan,
+				rulesDir:            rulesDir,
+				allowUnsafeLiveScan: allowUnsafeLiveScan,
 			})
 		},
 	}
@@ -129,22 +132,24 @@ func newScanCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print per-tool scan process tree to stderr during scan")
 	cmd.Flags().BoolVar(&deepScan, "deep-scan", false, "Enable AI-based semantic analysis for deep prompt injection detection (downloads a ~22MB quantized ONNX model on first run)")
 	cmd.Flags().StringVar(&rulesDir, "rules-dir", "", "path to directory containing custom YAML rules")
+	cmd.Flags().BoolVar(&allowUnsafeLiveScan, "allow-unsafe-live-scan", false, "acknowledge that --server executes the target command on the host before ToolTrust can score it")
 	// Mutual exclusivity checked in runScan
 
 	return cmd
 }
 
 type scanOpts struct {
-	inputFile  string
-	serverCmd  string
-	protocol   string
-	output     string
-	outputFile string
-	failOn     string
-	dbPath     string
-	verbose    bool
-	deepScan   bool
-	rulesDir   string
+	inputFile           string
+	serverCmd           string
+	protocol            string
+	output              string
+	outputFile          string
+	failOn              string
+	dbPath              string
+	verbose             bool
+	deepScan            bool
+	rulesDir            string
+	allowUnsafeLiveScan bool
 }
 
 func runScan(ctx context.Context, opts scanOpts) error {
@@ -178,11 +183,18 @@ func runScan(ctx context.Context, opts scanOpts) error {
 		if opts.protocol != "mcp" {
 			return fmt.Errorf("--server only supports the 'mcp' protocol")
 		}
+		if !opts.allowUnsafeLiveScan {
+			return fmt.Errorf("--server refuses to execute a live MCP command without --allow-unsafe-live-scan because the target process runs on the host before ToolTrust can score it")
+		}
 
 		liveCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
-		tools, err = scanLiveServer(liveCtx, opts.serverCmd)
+		args, parseErr := parseServerCommand(opts.serverCmd)
+		if parseErr != nil {
+			return parseErr
+		}
+		tools, err = scanLiveServerArgs(liveCtx, args, opts.serverCmd)
 		if err != nil {
 			return fmt.Errorf("live server scan failed (or timed out): %w", err)
 		}

--- a/cmd/tooltrust-scanner/main.go
+++ b/cmd/tooltrust-scanner/main.go
@@ -93,8 +93,8 @@ func newScanCmd() *cobra.Command {
 		verbose    bool
 		deepScan   bool
 		rulesDir   string
-		allowUnsafeLiveScan bool
 	)
+	var allowUnsafeLiveScan bool
 
 	cmd := &cobra.Command{
 		Use:   "scan",
@@ -117,8 +117,7 @@ func newScanCmd() *cobra.Command {
 				verbose:    verbose,
 				deepScan:   deepScan,
 				rulesDir:   rulesDir,
-				allowUnsafeLiveScan: allowUnsafeLiveScan,
-			})
+			}, allowUnsafeLiveScan)
 		},
 	}
 
@@ -149,10 +148,9 @@ type scanOpts struct {
 	verbose    bool
 	deepScan   bool
 	rulesDir   string
-	allowUnsafeLiveScan bool
 }
 
-func runScan(ctx context.Context, opts scanOpts) error {
+func runScan(ctx context.Context, opts scanOpts, allowUnsafeLiveScan bool) error {
 	// Validate --output flag early.
 	switch opts.output {
 	case "text", "json", "sarif":
@@ -183,7 +181,7 @@ func runScan(ctx context.Context, opts scanOpts) error {
 		if opts.protocol != "mcp" {
 			return fmt.Errorf("--server only supports the 'mcp' protocol")
 		}
-		if !opts.allowUnsafeLiveScan {
+		if !allowUnsafeLiveScan {
 			return fmt.Errorf("--server refuses to execute a live MCP command without --allow-unsafe-live-scan because the target process runs on the host before ToolTrust can score it")
 		}
 

--- a/cmd/tooltrust-scanner/main.go
+++ b/cmd/tooltrust-scanner/main.go
@@ -83,16 +83,16 @@ var severityWeight = map[model.Severity]int{
 
 func newScanCmd() *cobra.Command {
 	var (
-		inputFile           string
-		serverCmd           string
-		protocol            string
-		output              string
-		outputFile          string
-		failOn              string
-		dbPath              string
-		verbose             bool
-		deepScan            bool
-		rulesDir            string
+		inputFile  string
+		serverCmd  string
+		protocol   string
+		output     string
+		outputFile string
+		failOn     string
+		dbPath     string
+		verbose    bool
+		deepScan   bool
+		rulesDir   string
 		allowUnsafeLiveScan bool
 	)
 
@@ -107,16 +107,16 @@ func newScanCmd() *cobra.Command {
   tooltrust-scanner scan --input tools.json --db scans.db`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runScan(cmd.Context(), scanOpts{
-				inputFile:           inputFile,
-				serverCmd:           serverCmd,
-				protocol:            protocol,
-				output:              output,
-				outputFile:          outputFile,
-				failOn:              failOn,
-				dbPath:              dbPath,
-				verbose:             verbose,
-				deepScan:            deepScan,
-				rulesDir:            rulesDir,
+				inputFile:  inputFile,
+				serverCmd:  serverCmd,
+				protocol:   protocol,
+				output:     output,
+				outputFile: outputFile,
+				failOn:     failOn,
+				dbPath:     dbPath,
+				verbose:    verbose,
+				deepScan:   deepScan,
+				rulesDir:   rulesDir,
 				allowUnsafeLiveScan: allowUnsafeLiveScan,
 			})
 		},
@@ -139,16 +139,16 @@ func newScanCmd() *cobra.Command {
 }
 
 type scanOpts struct {
-	inputFile           string
-	serverCmd           string
-	protocol            string
-	output              string
-	outputFile          string
-	failOn              string
-	dbPath              string
-	verbose             bool
-	deepScan            bool
-	rulesDir            string
+	inputFile  string
+	serverCmd  string
+	protocol   string
+	output     string
+	outputFile string
+	failOn     string
+	dbPath     string
+	verbose    bool
+	deepScan   bool
+	rulesDir   string
 	allowUnsafeLiveScan bool
 }
 

--- a/cmd/tooltrust-scanner/main.go
+++ b/cmd/tooltrust-scanner/main.go
@@ -232,7 +232,7 @@ func runScan(ctx context.Context, opts scanOpts, allowUnsafeLiveScan bool) error
 			return fmt.Errorf("gateway evaluation failed for tool %q: %w", tools[i].Name, evalErr)
 		}
 		policy.Behavior, policy.Destinations = analyzer.SummarizeToolContext(tools[i])
-		policy.DependencyVisibility, policy.DependencyNote = dependencyVisibilityForTool(tools[i])
+		policy.DependencyVisibility, policy.DependencyNote = analyzer.DependencyVisibilityForTool(tools[i])
 		policies = append(policies, policy)
 
 		if opts.verbose {
@@ -658,85 +658,6 @@ func summarizeIssueReason(issue model.Issue) string {
 	return desc
 }
 
-func dependencyVisibilityForTool(tool model.UnifiedTool) (visibility, note string) {
-	if tool.Metadata == nil {
-		return "No dependency data", "No metadata.dependencies or repo_url were exposed by this MCP server."
-	}
-
-	sources := dependencySourcesFromMetadata(tool.Metadata)
-	if len(sources) == 0 {
-		note = metadataString(tool.Metadata, "dependency_visibility_note")
-		if note == "" {
-			note = "No metadata.dependencies or repo_url were exposed by this MCP server."
-		}
-		return "No dependency data", note
-	}
-	return formatDependencyVisibility(sources), visibilityNote(tool.Metadata, sources)
-}
-
-func dependencySourcesFromMetadata(meta map[string]any) []string {
-	seen := map[string]bool{}
-	var sources []string
-
-	if raw, ok := meta["dependencies"]; ok {
-		b, err := json.Marshal(raw)
-		if err == nil {
-			var deps []struct {
-				Source string `json:"source"`
-			}
-			if err := json.Unmarshal(b, &deps); err == nil {
-				for _, dep := range deps {
-					source := dep.Source
-					if source == "" {
-						source = "metadata"
-					}
-					if !seen[source] {
-						seen[source] = true
-						sources = append(sources, source)
-					}
-				}
-			}
-		}
-	}
-
-	if repoURL, ok := meta["repo_url"].(string); ok && strings.TrimSpace(repoURL) != "" {
-		if !seen["repo_url"] {
-			sources = append(sources, "repo_url")
-		}
-	}
-
-	return sources
-}
-
-func visibilityNote(meta map[string]any, sources []string) string {
-	if note := metadataString(meta, "dependency_visibility_note"); note != "" {
-		return note
-	}
-	if len(sources) == 1 && sources[0] == "repo_url" {
-		return "repo_url is available, so ToolTrust can try to inspect remote lockfiles for dependency evidence."
-	}
-	return ""
-}
-
-func formatDependencyVisibility(sources []string) string {
-	labels := make([]string, 0, len(sources))
-	for _, source := range sources {
-		switch source {
-		case "metadata":
-			labels = append(labels, "Declared by MCP metadata")
-		case "local_lockfile":
-			labels = append(labels, "Verified from local lockfile")
-		case "lockfile":
-			labels = append(labels, "Verified from remote lockfile")
-		case "repo_url":
-			labels = append(labels, "Repo URL available")
-		default:
-			labels = append(labels, source)
-		}
-	}
-	return strings.Join(labels, " + ")
-}
-
 // formatToolLabel returns a coloured "Tool: <name>  [ACTION]" label.
 func formatToolLabel(policy model.GatewayPolicy) string {
 	name := fmt.Sprintf("Tool: %s", policy.ToolName)
@@ -895,13 +816,6 @@ func avgRiskScore(policies []model.GatewayPolicy) (int, model.Grade) {
 	}
 	avg := total / len(policies)
 	return avg, model.GradeFromScore(avg)
-}
-
-func metadataString(meta map[string]any, key string) string {
-	if value, ok := meta[key].(string); ok {
-		return value
-	}
-	return ""
 }
 
 // printScanPtree writes a tree view of the scan process to w (stderr) during verbose scan.

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -332,7 +333,9 @@ func TestEnrichLiveToolsWithLocalNodeDependencies(t *testing.T) {
 		_ = os.Chdir(prevWD)
 	})
 
-	tools := enrichLiveToolsWithLocalNodeDependencies([]string{"npm", "run", "dev"}, []model.UnifiedTool{{
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "server.js"), []byte(`console.log("hello")`), 0o644))
+
+	tools := enrichLiveToolsWithLocalNodeDependencies([]string{"node", "./server.js"}, []model.UnifiedTool{{
 		Name: "deploy_site",
 	}})
 	require.Len(t, tools, 1)
@@ -345,4 +348,69 @@ func TestEnrichLiveToolsWithLocalNodeDependencies(t *testing.T) {
 	require.Len(t, rawDeps, 1)
 	assert.Equal(t, "axios", rawDeps[0]["name"])
 	assert.Equal(t, "local_lockfile", rawDeps[0]["source"])
+}
+
+func TestEnrichLiveToolsWithLocalNodeDependencies_DoesNotUseCallerCWD(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "package.json"), []byte(`{"name":"demo"}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "package-lock.json"), []byte(`{
+  "packages": {
+    "": {"version": "1.0.0"},
+    "node_modules/axios": {"version": "1.14.1"}
+  }
+}`), 0o644))
+
+	prevWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+
+	tools := enrichLiveToolsWithLocalNodeDependencies([]string{"npx", "-y", "@modelcontextprotocol/server-memory"}, []model.UnifiedTool{{
+		Name: "memory",
+	}})
+	require.Len(t, tools, 1)
+
+	visibility, note := dependencyVisibilityForTool(tools[0])
+	assert.Equal(t, "No dependency data", visibility)
+	assert.Contains(t, note, "No metadata.dependencies or repo_url")
+	_, hasDeps := tools[0].Metadata["dependencies"]
+	assert.False(t, hasDeps)
+}
+
+func TestRunScan_ServerRequiresUnsafeLiveScanOptIn(t *testing.T) {
+	err := runScan(context.Background(), scanOpts{
+		serverCmd: `npx -y @modelcontextprotocol/server-memory`,
+		protocol:  "mcp",
+		output:    "text",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--allow-unsafe-live-scan")
+}
+
+func TestParseYarnLockfile_ParsesYarnBerryEntries(t *testing.T) {
+	tmp := t.TempDir()
+	lockfile := filepath.Join(tmp, "yarn.lock")
+	require.NoError(t, os.WriteFile(lockfile, []byte(`
+__metadata:
+  version: 8
+
+"axios@npm:^1.14.1":
+  version: 1.14.1
+
+"@scope/sdk@npm:^2.3.4":
+  version: 2.3.4
+`), 0o644))
+
+	deps, err := parseYarnLockfile(lockfile)
+	require.NoError(t, err)
+	require.Len(t, deps, 2)
+
+	got := map[string]string{}
+	for _, dep := range deps {
+		got[dep.Name] = dep.Version
+	}
+	assert.Equal(t, "1.14.1", got["axios"])
+	assert.Equal(t, "2.3.4", got["@scope/sdk"])
 }

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -384,7 +384,7 @@ func TestRunScan_ServerRequiresUnsafeLiveScanOptIn(t *testing.T) {
 		serverCmd: `npx -y @modelcontextprotocol/server-memory`,
 		protocol:  "mcp",
 		output:    "text",
-	})
+	}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--allow-unsafe-live-scan")
 }

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -446,12 +446,13 @@ func TestParseRequirementsFile_StripsMarkersAndInlineComments(t *testing.T) {
 	require.NoError(t, os.WriteFile(requirements, []byte(`
 django==4.2.0 # security fixture
 Flask==2.3.1 ; python_version >= "3.8"
+requests[security]==2.32.0
 requests>=2.28.0
 `), 0o644))
 
 	deps, err := parseRequirementsFile(requirements)
 	require.NoError(t, err)
-	require.Len(t, deps, 2)
+	require.Len(t, deps, 3)
 
 	got := map[string]string{}
 	for _, dep := range deps {
@@ -459,4 +460,5 @@ requests>=2.28.0
 	}
 	assert.Equal(t, "4.2.0", got["django"])
 	assert.Equal(t, "2.3.1", got["Flask"])
+	assert.Equal(t, "2.32.0", got["requests"])
 }

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/analyzer"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
 
@@ -230,7 +231,7 @@ func TestToolReasonLabel_ForBlock(t *testing.T) {
 }
 
 func TestDependencyVisibilityForTool_None(t *testing.T) {
-	visibility, note := dependencyVisibilityForTool(model.UnifiedTool{
+	visibility, note := analyzer.DependencyVisibilityForTool(model.UnifiedTool{
 		Name: "plain_tool",
 	})
 
@@ -239,7 +240,7 @@ func TestDependencyVisibilityForTool_None(t *testing.T) {
 }
 
 func TestDependencyVisibilityForTool_MetadataAndRepoURL(t *testing.T) {
-	visibility, note := dependencyVisibilityForTool(model.UnifiedTool{
+	visibility, note := analyzer.DependencyVisibilityForTool(model.UnifiedTool{
 		Name: "tool",
 		Metadata: map[string]any{
 			"repo_url": "https://github.com/example/repo",
@@ -339,7 +340,7 @@ func TestEnrichLiveToolsWithLocalNodeDependencies(t *testing.T) {
 		Name: "deploy_site",
 	}})
 	require.Len(t, tools, 1)
-	visibility, note := dependencyVisibilityForTool(tools[0])
+	visibility, note := analyzer.DependencyVisibilityForTool(tools[0])
 	assert.Equal(t, "Verified from local lockfile", visibility)
 	assert.Contains(t, note, "Local dependency artifacts scanned")
 
@@ -372,7 +373,7 @@ func TestEnrichLiveToolsWithLocalNodeDependencies_DoesNotUseCallerCWD(t *testing
 	}})
 	require.Len(t, tools, 1)
 
-	visibility, note := dependencyVisibilityForTool(tools[0])
+	visibility, note := analyzer.DependencyVisibilityForTool(tools[0])
 	assert.Equal(t, "No dependency data", visibility)
 	assert.Contains(t, note, "No metadata.dependencies or repo_url")
 	_, hasDeps := tools[0].Metadata["dependencies"]

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -414,3 +414,48 @@ __metadata:
 	assert.Equal(t, "1.14.1", got["axios"])
 	assert.Equal(t, "2.3.4", got["@scope/sdk"])
 }
+
+func TestParsePNPMLockfile_StripsPeerDependencySuffix(t *testing.T) {
+	tmp := t.TempDir()
+	lockfile := filepath.Join(tmp, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lockfile, []byte(`
+lockfileVersion: '9.0'
+packages:
+  /axios@1.14.1:
+    resolution: {integrity: sha512-abc}
+  /@scope/sdk@2.3.4(axios@1.14.1):
+    resolution: {integrity: sha512-def}
+`), 0o644))
+
+	deps, err := parsePNPMLockfile(lockfile)
+	require.NoError(t, err)
+	require.Len(t, deps, 2)
+
+	got := map[string]string{}
+	for _, dep := range deps {
+		got[dep.Name] = dep.Version
+	}
+	assert.Equal(t, "1.14.1", got["axios"])
+	assert.Equal(t, "2.3.4", got["@scope/sdk"])
+}
+
+func TestParseRequirementsFile_StripsMarkersAndInlineComments(t *testing.T) {
+	tmp := t.TempDir()
+	requirements := filepath.Join(tmp, "requirements.txt")
+	require.NoError(t, os.WriteFile(requirements, []byte(`
+django==4.2.0 # security fixture
+Flask==2.3.1 ; python_version >= "3.8"
+requests>=2.28.0
+`), 0o644))
+
+	deps, err := parseRequirementsFile(requirements)
+	require.NoError(t, err)
+	require.Len(t, deps, 2)
+
+	got := map[string]string{}
+	for _, dep := range deps {
+		got[dep.Name] = dep.Version
+	}
+	assert.Equal(t, "4.2.0", got["django"])
+	assert.Equal(t, "2.3.1", got["Flask"])
+}

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -447,12 +447,13 @@ func TestParseRequirementsFile_StripsMarkersAndInlineComments(t *testing.T) {
 django==4.2.0 # security fixture
 Flask==2.3.1 ; python_version >= "3.8"
 requests[security]==2.32.0
+urllib3===2.0.0
 requests>=2.28.0
 `), 0o644))
 
 	deps, err := parseRequirementsFile(requirements)
 	require.NoError(t, err)
-	require.Len(t, deps, 3)
+	require.Len(t, deps, 4)
 
 	got := map[string]string{}
 	for _, dep := range deps {
@@ -461,4 +462,5 @@ requests>=2.28.0
 	assert.Equal(t, "4.2.0", got["django"])
 	assert.Equal(t, "2.3.1", got["Flask"])
 	assert.Equal(t, "2.32.0", got["requests"])
+	assert.Equal(t, "2.0.0", got["urllib3"])
 }

--- a/cmd/tooltrust-scanner/main_test.go
+++ b/cmd/tooltrust-scanner/main_test.go
@@ -448,12 +448,15 @@ django==4.2.0 # security fixture
 Flask==2.3.1 ; python_version >= "3.8"
 requests[security]==2.32.0
 urllib3===2.0.0
+certifi==2024.2.2 --hash=sha256:abc123
+idna==3.6 \
+    --hash=sha256:def456
 requests>=2.28.0
 `), 0o644))
 
 	deps, err := parseRequirementsFile(requirements)
 	require.NoError(t, err)
-	require.Len(t, deps, 4)
+	require.Len(t, deps, 6)
 
 	got := map[string]string{}
 	for _, dep := range deps {
@@ -463,4 +466,6 @@ requests>=2.28.0
 	assert.Equal(t, "2.3.1", got["Flask"])
 	assert.Equal(t, "2.32.0", got["requests"])
 	assert.Equal(t, "2.0.0", got["urllib3"])
+	assert.Equal(t, "2024.2.2", got["certifi"])
+	assert.Equal(t, "3.6", got["idna"])
 }

--- a/internal/jsonschema/schema.go
+++ b/internal/jsonschema/schema.go
@@ -7,6 +7,7 @@ type Property struct {
 	Enum        []any               `json:"enum,omitempty"`
 	Properties  map[string]Property `json:"properties,omitempty"`
 	Items       *Property           `json:"items,omitempty"`
+	Required    []string            `json:"required,omitempty"`
 }
 
 // Schema is a minimal JSON Schema (draft-07 compatible) used throughout ToolTrust Scanner.
@@ -16,6 +17,13 @@ type Schema struct {
 	Properties  map[string]Property `json:"properties,omitempty"`
 	Required    []string            `json:"required,omitempty"`
 	Items       *Property           `json:"items,omitempty"`
+}
+
+// PropertyRef captures a schema property together with its fully-qualified path.
+type PropertyRef struct {
+	Name     string
+	Path     string
+	Property Property
 }
 
 // PropertyNames returns the sorted list of property keys defined in the schema.
@@ -34,4 +42,46 @@ func (s Schema) PropertyNames() []string {
 func (s Schema) HasProperty(name string) bool {
 	_, ok := s.Properties[name]
 	return ok
+}
+
+// WalkProperties visits every schema property, including nested objects and array items.
+func (s Schema) WalkProperties(fn func(PropertyRef)) {
+	if fn == nil {
+		return
+	}
+	walkPropertyMap("", s.Properties, fn)
+	if s.Items != nil {
+		walkProperty("[]", *s.Items, fn)
+	}
+}
+
+// PropertyCount returns the total number of schema properties, including nested ones.
+func (s Schema) PropertyCount() int {
+	count := 0
+	s.WalkProperties(func(_ PropertyRef) {
+		count++
+	})
+	return count
+}
+
+func walkPropertyMap(prefix string, props map[string]Property, fn func(PropertyRef)) {
+	for name, prop := range props {
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		fn(PropertyRef{Name: name, Path: path, Property: prop})
+		walkProperty(path, prop, fn)
+	}
+}
+
+func walkProperty(prefix string, prop Property, fn func(PropertyRef)) {
+	if len(prop.Properties) > 0 {
+		walkPropertyMap(prefix, prop.Properties, fn)
+	}
+	if prop.Items != nil {
+		itemPath := prefix + "[]"
+		fn(PropertyRef{Name: "[]", Path: itemPath, Property: *prop.Items})
+		walkProperty(itemPath, *prop.Items, fn)
+	}
 }

--- a/internal/userhome/home.go
+++ b/internal/userhome/home.go
@@ -1,0 +1,29 @@
+package userhome
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Resolve returns the most explicit home directory available from the
+// environment before falling back to os.UserHomeDir().
+func Resolve() (string, error) {
+	for _, key := range []string{"HOME", "USERPROFILE"} {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value, nil
+		}
+	}
+
+	drive := strings.TrimSpace(os.Getenv("HOMEDRIVE"))
+	path := strings.TrimSpace(os.Getenv("HOMEPATH"))
+	if drive != "" && path != "" {
+		return drive + path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory: %w", err)
+	}
+	return home, nil
+}

--- a/npm/bin/run.js
+++ b/npm/bin/run.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 const { spawn } = require('child_process');
+const pkg = require('../package.json');
 
 const platformMap = {
   darwin: 'darwin',
@@ -30,9 +31,10 @@ if (!goos || !goarch) {
 
 const suffix = goos === 'windows' ? '.exe' : '';
 const binName = `tooltrust-mcp_${goos}_${goarch}${suffix}`;
-const downloadUrl = `https://github.com/AgentSafe-AI/tooltrust-scanner/releases/latest/download/${binName}`;
+const releaseTag = `v${pkg.version}`;
+const downloadUrl = `https://github.com/AgentSafe-AI/tooltrust-scanner/releases/download/${releaseTag}/${binName}`;
 
-const cacheDir = path.join(os.homedir(), '.tooltrust-mcp', 'bin');
+const cacheDir = path.join(os.homedir(), '.tooltrust-mcp', 'bin', releaseTag);
 const binPath = path.join(cacheDir, binName);
 
 function downloadFile(url, dest) {
@@ -72,7 +74,6 @@ function runBinary(args) {
 }
 
 async function main() {
-  const pkg = require('../package.json');
   const args = process.argv.slice(2);
 
   // --version is the only flag handled by the wrapper (shows npm package version).

--- a/pkg/adapter/mcp/adapter.go
+++ b/pkg/adapter/mcp/adapter.go
@@ -51,12 +51,22 @@ func (a *Adapter) Parse(_ context.Context, data []byte) ([]model.UnifiedTool, er
 func buildMetadata(t Tool) map[string]any {
 	meta := map[string]any{}
 
+	for key, value := range t.Metadata.Extra {
+		meta[key] = value
+	}
+
 	repoURL := strings.TrimSpace(t.Metadata.RepoURL)
 	if repoURL == "" {
 		repoURL = strings.TrimSpace(t.RepoURL)
 	}
 	if repoURL != "" {
 		meta["repo_url"] = repoURL
+	}
+
+	if len(t.Metadata.OAuthScopes) > 0 {
+		scopes := make([]string, len(t.Metadata.OAuthScopes))
+		copy(scopes, t.Metadata.OAuthScopes)
+		meta["oauth_scopes"] = scopes
 	}
 
 	if len(t.Metadata.Dependencies) > 0 {
@@ -86,17 +96,38 @@ func buildMetadata(t Tool) map[string]any {
 func convertSchema(s InputSchema) jsonschema.Schema {
 	props := make(map[string]jsonschema.Property, len(s.Properties))
 	for k, v := range s.Properties {
-		props[k] = jsonschema.Property{
-			Type:        string(v.Type),
-			Description: v.Description,
-		}
+		props[k] = convertProperty(v)
 	}
 	return jsonschema.Schema{
 		Type:        string(s.Type),
 		Description: s.Description,
 		Properties:  props,
 		Required:    s.Required,
+		Items:       convertPropertyPtr(s.Items),
 	}
+}
+
+func convertProperty(p SchemaProperty) jsonschema.Property {
+	props := make(map[string]jsonschema.Property, len(p.Properties))
+	for k, v := range p.Properties {
+		props[k] = convertProperty(v)
+	}
+	return jsonschema.Property{
+		Type:        string(p.Type),
+		Description: p.Description,
+		Enum:        p.Enum,
+		Properties:  props,
+		Required:    p.Required,
+		Items:       convertPropertyPtr(p.Items),
+	}
+}
+
+func convertPropertyPtr(p *SchemaProperty) *jsonschema.Property {
+	if p == nil {
+		return nil
+	}
+	prop := convertProperty(*p)
+	return &prop
 }
 
 // permissionRule maps keyword signals to a Permission.
@@ -176,15 +207,14 @@ func inferPermissions(t Tool) []model.Permission {
 	}
 
 	for _, entry := range permissionRules {
-		// Check schema property names
-		for propKey := range t.InputSchema.Properties {
-			propLower := strings.ToLower(propKey)
+		walkInputSchemaProperties(t.InputSchema, func(propPath string, _ SchemaProperty) {
+			propLower := strings.ToLower(propPath)
 			for _, ruleKey := range entry.rule.propKeys {
 				if propLower == ruleKey || strings.Contains(propLower, ruleKey) {
 					add(entry.permission)
 				}
 			}
-		}
+		})
 		// Check description keywords
 		for _, kw := range entry.rule.descKeywords {
 			if strings.Contains(descLower, kw) {
@@ -199,4 +229,30 @@ func inferPermissions(t Tool) []model.Permission {
 		}
 	}
 	return perms
+}
+
+func walkInputSchemaProperties(schema InputSchema, fn func(path string, prop SchemaProperty)) {
+	for name, prop := range schema.Properties {
+		walkSchemaProperty(name, prop, fn)
+	}
+	if schema.Items != nil {
+		walkSchemaProperty("[]", *schema.Items, fn)
+	}
+}
+
+func walkSchemaProperty(prefix string, prop SchemaProperty, fn func(path string, prop SchemaProperty)) {
+	if fn != nil {
+		fn(prefix, prop)
+	}
+	for name, child := range prop.Properties {
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		walkSchemaProperty(path, child, fn)
+	}
+	if prop.Items != nil {
+		itemPath := prefix + "[]"
+		walkSchemaProperty(itemPath, *prop.Items, fn)
+	}
 }

--- a/pkg/adapter/mcp/adapter.go
+++ b/pkg/adapter/mcp/adapter.go
@@ -21,14 +21,18 @@ func (a *Adapter) Protocol() model.ProtocolType { return model.ProtocolMCP }
 
 // Parse implements adapter.Adapter for the MCP tools/list response format.
 func (a *Adapter) Parse(_ context.Context, data []byte) ([]model.UnifiedTool, error) {
-	var resp ListToolsResponse
+	var resp listToolsEnvelope
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, fmt.Errorf("mcp adapter: failed to parse tools/list response: %w", err)
 	}
+	toolList := resp.Tools
+	if toolList == nil && resp.Result != nil {
+		toolList = resp.Result.Tools
+	}
 
-	tools := make([]model.UnifiedTool, 0, len(resp.Tools))
-	for i := range resp.Tools {
-		t := resp.Tools[i]
+	tools := make([]model.UnifiedTool, 0, len(toolList))
+	for i := range toolList {
+		t := toolList[i]
 		raw, err := json.Marshal(t)
 		if err != nil {
 			// Marshalling a plain struct with only string fields should never fail.

--- a/pkg/adapter/mcp/adapter.go
+++ b/pkg/adapter/mcp/adapter.go
@@ -75,11 +75,15 @@ func buildMetadata(t Tool) map[string]any {
 			if dep.Name == "" || dep.Version == "" || dep.Ecosystem == "" {
 				continue
 			}
-			deps = append(deps, map[string]any{
+			entry := map[string]any{
 				"name":      dep.Name,
 				"version":   dep.Version,
 				"ecosystem": dep.Ecosystem,
-			})
+			}
+			if dep.Source != "" {
+				entry["source"] = dep.Source
+			}
+			deps = append(deps, entry)
 		}
 		if len(deps) > 0 {
 			meta["dependencies"] = deps

--- a/pkg/adapter/mcp/adapter.go
+++ b/pkg/adapter/mcp/adapter.go
@@ -55,27 +55,41 @@ func (a *Adapter) Parse(_ context.Context, data []byte) ([]model.UnifiedTool, er
 func buildMetadata(t Tool) map[string]any {
 	meta := map[string]any{}
 
-	for key, value := range t.Metadata.Extra {
+	mergeToolMeta(meta, t.Meta)
+	mergeToolMeta(meta, t.Metadata)
+
+	if _, ok := meta["repo_url"]; !ok {
+		repoURL := strings.TrimSpace(t.RepoURL)
+		if repoURL != "" {
+			meta["repo_url"] = repoURL
+		}
+	}
+
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+func mergeToolMeta(meta map[string]any, toolMeta ToolMeta) {
+	for key, value := range toolMeta.Extra {
 		meta[key] = value
 	}
 
-	repoURL := strings.TrimSpace(t.Metadata.RepoURL)
-	if repoURL == "" {
-		repoURL = strings.TrimSpace(t.RepoURL)
-	}
+	repoURL := strings.TrimSpace(toolMeta.RepoURL)
 	if repoURL != "" {
 		meta["repo_url"] = repoURL
 	}
 
-	if len(t.Metadata.OAuthScopes) > 0 {
-		scopes := make([]string, len(t.Metadata.OAuthScopes))
-		copy(scopes, t.Metadata.OAuthScopes)
+	if len(toolMeta.OAuthScopes) > 0 {
+		scopes := make([]string, len(toolMeta.OAuthScopes))
+		copy(scopes, toolMeta.OAuthScopes)
 		meta["oauth_scopes"] = scopes
 	}
 
-	if len(t.Metadata.Dependencies) > 0 {
-		deps := make([]map[string]any, 0, len(t.Metadata.Dependencies))
-		for _, dep := range t.Metadata.Dependencies {
+	if len(toolMeta.Dependencies) > 0 {
+		deps := make([]map[string]any, 0, len(toolMeta.Dependencies))
+		for _, dep := range toolMeta.Dependencies {
 			if dep.Name == "" || dep.Version == "" || dep.Ecosystem == "" {
 				continue
 			}
@@ -93,11 +107,6 @@ func buildMetadata(t Tool) map[string]any {
 			meta["dependencies"] = deps
 		}
 	}
-
-	if len(meta) == 0 {
-		return nil
-	}
-	return meta
 }
 
 // convertSchema maps an MCP InputSchema to the internal jsonschema.Schema.

--- a/pkg/adapter/mcp/adapter_test.go
+++ b/pkg/adapter/mcp/adapter_test.go
@@ -292,6 +292,68 @@ func TestAdapter_Parse_ArrayTypeField(t *testing.T) {
 	assert.Equal(t, "boolean", tools[0].InputSchema.Properties["hidden"].Type)
 }
 
+func TestAdapter_Parse_PreservesNestedSchemaAndMetadata(t *testing.T) {
+	payload := []byte(`{
+		"tools": [{
+			"name": "deploy",
+			"description": "Deploy to a remote endpoint",
+			"metadata": {
+				"oauth_scopes": ["repo"],
+				"timeout_ms": 5000
+			},
+			"inputSchema": {
+				"type": "object",
+				"properties": {
+					"auth": {
+						"type": "object",
+						"properties": {
+							"client_secret": {"type": "string"}
+						}
+					},
+					"request": {
+						"type": "object",
+						"properties": {
+							"url": {"type": "string"},
+							"timeout": {"type": "integer"}
+						}
+					}
+				}
+			}
+		}]
+	}`)
+
+	tools, err := mcp.NewAdapter().Parse(context.Background(), payload)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	tool := tools[0]
+	require.NotNil(t, tool.Metadata)
+	assert.Equal(t, []string{"repo"}, tool.Metadata["oauth_scopes"])
+	assert.Equal(t, float64(5000), tool.Metadata["timeout_ms"])
+	assert.Equal(t, 5, tool.InputSchema.PropertyCount())
+	assert.Equal(t, "string", tool.InputSchema.Properties["auth"].Properties["client_secret"].Type)
+	assert.Equal(t, "string", tool.InputSchema.Properties["request"].Properties["url"].Type)
+
+	scanner, err := analyzer.NewScanner(false, "")
+	require.NoError(t, err)
+	score, err := scanner.Scan(context.Background(), tool)
+	require.NoError(t, err)
+	assertIssue := func(ruleID string) {
+		t.Helper()
+		for _, issue := range score.Issues {
+			if issue.RuleID == ruleID {
+				return
+			}
+		}
+		t.Fatalf("expected %s in scan issues, got %#v", ruleID, score.Issues)
+	}
+	assertIssue("AS-005")
+	assertIssue("AS-010")
+	for _, issue := range score.Issues {
+		require.NotEqual(t, "AS-011", issue.RuleID, "nested timeout signal should suppress AS-011")
+	}
+}
+
 func mustMarshal(v any) []byte {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/pkg/adapter/mcp/adapter_test.go
+++ b/pkg/adapter/mcp/adapter_test.go
@@ -160,6 +160,35 @@ func TestAdapter_Parse_PopulatesSupplyChainMetadata(t *testing.T) {
 	assert.Equal(t, "npm", deps[0]["ecosystem"])
 }
 
+func TestAdapter_Parse_PreservesDependencySource(t *testing.T) {
+	payload := []byte(`{
+		"tools": [{
+			"name": "deploy_site",
+			"description": "Deploy the site",
+			"metadata": {
+				"dependencies": [{
+					"name": "axios",
+					"version": "1.14.1",
+					"ecosystem": "npm",
+					"source": "local_lockfile"
+				}]
+			}
+		}]
+	}`)
+
+	tools, err := mcp.NewAdapter().Parse(context.Background(), payload)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	deps, ok := tools[0].Metadata["dependencies"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "local_lockfile", deps[0]["source"])
+
+	visibility, _ := analyzer.DependencyVisibilityForTool(tools[0])
+	assert.Equal(t, "Verified from local lockfile", visibility)
+}
+
 func TestAdapter_Parse_PrefersMetadataRepoURL(t *testing.T) {
 	payload := mustMarshal(mcp.ListToolsResponse{
 		Tools: []mcp.Tool{

--- a/pkg/adapter/mcp/adapter_test.go
+++ b/pkg/adapter/mcp/adapter_test.go
@@ -103,6 +103,31 @@ func TestAdapter_Parse_MultipleTools(t *testing.T) {
 	assert.Len(t, tools, 2)
 }
 
+func TestAdapter_Parse_JSONRPCListToolsResponse(t *testing.T) {
+	payload := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"result": {
+			"tools": [{
+				"name": "read_file",
+				"description": "Read a file from disk",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"path": {"type": "string"}
+					}
+				}
+			}]
+		}
+	}`)
+
+	tools, err := mcp.NewAdapter().Parse(context.Background(), payload)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "read_file", tools[0].Name)
+	assert.Contains(t, tools[0].Permissions, model.PermissionFS)
+}
+
 func TestAdapter_Parse_EmptyList(t *testing.T) {
 	payload := mustMarshal(mcp.ListToolsResponse{Tools: []mcp.Tool{}})
 	tools, err := mcp.NewAdapter().Parse(context.Background(), payload)

--- a/pkg/adapter/mcp/adapter_test.go
+++ b/pkg/adapter/mcp/adapter_test.go
@@ -185,6 +185,40 @@ func TestAdapter_Parse_PopulatesSupplyChainMetadata(t *testing.T) {
 	assert.Equal(t, "npm", deps[0]["ecosystem"])
 }
 
+func TestAdapter_Parse_PreservesProtocolMeta(t *testing.T) {
+	payload := []byte(`{
+		"tools": [{
+			"name": "deploy_site",
+			"description": "Deploy the site",
+			"_meta": {
+				"repo_url": "https://github.com/example/site",
+				"oauth_scopes": ["repo"],
+				"dependencies": [{
+					"name": "axios",
+					"version": "1.14.1",
+					"ecosystem": "npm",
+					"source": "metadata"
+				}],
+				"timeout_ms": 5000
+			}
+		}]
+	}`)
+
+	tools, err := mcp.NewAdapter().Parse(context.Background(), payload)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	meta := tools[0].Metadata
+	require.NotNil(t, meta)
+	assert.Equal(t, "https://github.com/example/site", meta["repo_url"])
+	assert.Equal(t, []string{"repo"}, meta["oauth_scopes"])
+	assert.Equal(t, float64(5000), meta["timeout_ms"])
+	deps, ok := meta["dependencies"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "metadata", deps[0]["source"])
+}
+
 func TestAdapter_Parse_PreservesDependencySource(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{

--- a/pkg/adapter/mcp/types.go
+++ b/pkg/adapter/mcp/types.go
@@ -60,6 +60,49 @@ type Tool struct {
 type ToolMeta struct {
 	RepoURL      string               `json:"repo_url,omitempty"`
 	Dependencies []DependencyMetadata `json:"dependencies,omitempty"`
+	OAuthScopes  []string             `json:"oauth_scopes,omitempty"`
+	Extra        map[string]any       `json:"-"`
+}
+
+// UnmarshalJSON preserves unknown metadata fields so downstream analyzers can inspect them.
+func (m *ToolMeta) UnmarshalJSON(data []byte) error {
+	type alias ToolMeta
+	var parsed alias
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+
+	var extra map[string]any
+	if err := json.Unmarshal(data, &extra); err != nil {
+		return err
+	}
+	delete(extra, "repo_url")
+	delete(extra, "dependencies")
+	delete(extra, "oauth_scopes")
+
+	*m = ToolMeta(parsed)
+	if len(extra) > 0 {
+		m.Extra = extra
+	}
+	return nil
+}
+
+// MarshalJSON keeps the preserved metadata keys when fixtures/tests re-encode ToolMeta.
+func (m ToolMeta) MarshalJSON() ([]byte, error) {
+	out := map[string]any{}
+	for key, value := range m.Extra {
+		out[key] = value
+	}
+	if m.RepoURL != "" {
+		out["repo_url"] = m.RepoURL
+	}
+	if len(m.Dependencies) > 0 {
+		out["dependencies"] = m.Dependencies
+	}
+	if len(m.OAuthScopes) > 0 {
+		out["oauth_scopes"] = m.OAuthScopes
+	}
+	return json.Marshal(out)
 }
 
 // DependencyMetadata is the MCP-side representation of a package dependency.
@@ -75,10 +118,15 @@ type InputSchema struct {
 	Properties  map[string]SchemaProperty `json:"properties,omitempty"`
 	Required    []string                  `json:"required,omitempty"`
 	Description string                    `json:"description,omitempty"`
+	Items       *SchemaProperty           `json:"items,omitempty"`
 }
 
 // SchemaProperty describes a single property within an InputSchema.
 type SchemaProperty struct {
-	Type        FlexType `json:"type,omitempty"`
-	Description string   `json:"description,omitempty"`
+	Type        FlexType                  `json:"type,omitempty"`
+	Description string                    `json:"description,omitempty"`
+	Enum        []any                     `json:"enum,omitempty"`
+	Properties  map[string]SchemaProperty `json:"properties,omitempty"`
+	Required    []string                  `json:"required,omitempty"`
+	Items       *SchemaProperty           `json:"items,omitempty"`
 }

--- a/pkg/adapter/mcp/types.go
+++ b/pkg/adapter/mcp/types.go
@@ -69,12 +69,12 @@ func (m *ToolMeta) UnmarshalJSON(data []byte) error {
 	type alias ToolMeta
 	var parsed alias
 	if err := json.Unmarshal(data, &parsed); err != nil {
-		return err
+		return fmt.Errorf("ToolMeta: unmarshal known fields: %w", err)
 	}
 
 	var extra map[string]any
 	if err := json.Unmarshal(data, &extra); err != nil {
-		return err
+		return fmt.Errorf("ToolMeta: unmarshal extra fields: %w", err)
 	}
 	delete(extra, "repo_url")
 	delete(extra, "dependencies")
@@ -102,7 +102,11 @@ func (m ToolMeta) MarshalJSON() ([]byte, error) {
 	if len(m.OAuthScopes) > 0 {
 		out["oauth_scopes"] = m.OAuthScopes
 	}
-	return json.Marshal(out)
+	data, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("ToolMeta: marshal: %w", err)
+	}
+	return data, nil
 }
 
 // DependencyMetadata is the MCP-side representation of a package dependency.

--- a/pkg/adapter/mcp/types.go
+++ b/pkg/adapter/mcp/types.go
@@ -114,6 +114,7 @@ type DependencyMetadata struct {
 	Name      string `json:"name"`
 	Version   string `json:"version"`
 	Ecosystem string `json:"ecosystem"`
+	Source    string `json:"source,omitempty"`
 }
 
 // InputSchema is the JSON Schema fragment embedded in an MCP Tool.

--- a/pkg/adapter/mcp/types.go
+++ b/pkg/adapter/mcp/types.go
@@ -47,6 +47,11 @@ type ListToolsResponse struct {
 	Tools []Tool `json:"tools"`
 }
 
+type listToolsEnvelope struct {
+	Tools  []Tool             `json:"tools"`
+	Result *ListToolsResponse `json:"result,omitempty"`
+}
+
 // Tool is a single tool entry in the MCP tools/list response.
 type Tool struct {
 	Name        string      `json:"name"`

--- a/pkg/adapter/mcp/types.go
+++ b/pkg/adapter/mcp/types.go
@@ -58,6 +58,7 @@ type Tool struct {
 	Description string      `json:"description"`
 	InputSchema InputSchema `json:"inputSchema"`
 	RepoURL     string      `json:"repo_url,omitempty"`
+	Meta        ToolMeta    `json:"_meta,omitempty"`
 	Metadata    ToolMeta    `json:"metadata,omitempty"`
 }
 

--- a/pkg/analyzer/context.go
+++ b/pkg/analyzer/context.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/AgentSafe-AI/tooltrust-scanner/internal/jsonschema"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
 
@@ -65,11 +66,11 @@ func SummarizeToolContext(tool model.UnifiedTool) (behavior, destinations []stri
 		}
 	}
 
-	for propName := range tool.InputSchema.Properties {
-		if label := classifyDynamicDestination(propName); label != "" {
+	tool.InputSchema.WalkProperties(func(ref jsonschema.PropertyRef) {
+		if label := classifyDynamicDestination(ref.Path); label != "" {
 			destinationSet[label] = true
 		}
-	}
+	})
 
 	for _, match := range hardcodedURLPattern.FindAllString(string(tool.RawSource), -1) {
 		addHardcodedDestination(destinationSet, match)

--- a/pkg/analyzer/context_test.go
+++ b/pkg/analyzer/context_test.go
@@ -171,3 +171,25 @@ func TestSummarizeToolContext_ClassifiesHardcodedAPIEndpoint(t *testing.T) {
 
 	assert.Contains(t, destinations, "hardcoded API endpoint: api.postmarkapp.com")
 }
+
+func TestSummarizeToolContext_UsesNestedURLInput(t *testing.T) {
+	tool := model.UnifiedTool{
+		Name:        "fetch_remote",
+		Description: "Fetch a remote resource over HTTPS.",
+		Permissions: []model.Permission{model.PermissionNetwork},
+		InputSchema: jsonschema.Schema{
+			Properties: map[string]jsonschema.Property{
+				"request": {
+					Type: "object",
+					Properties: map[string]jsonschema.Property{
+						"url": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	_, destinations := SummarizeToolContext(tool)
+
+	assert.Equal(t, []string{"dynamic URL input (request.url)"}, destinations)
+}

--- a/pkg/analyzer/dependency_inventory.go
+++ b/pkg/analyzer/dependency_inventory.go
@@ -1,6 +1,8 @@
 package analyzer
 
 import (
+	"strings"
+
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
 
@@ -25,8 +27,7 @@ func (c *DependencyInventoryChecker) Check(tool model.UnifiedTool) ([]model.Issu
 		return nil, nil
 	}
 
-	deps, err := collectDependencies(tool)
-	if err != nil || len(deps) > 0 {
+	if hasDependencyInventory(tool) {
 		return nil, nil
 	}
 
@@ -48,6 +49,17 @@ func (c *DependencyInventoryChecker) Check(tool model.UnifiedTool) ([]model.Issu
 			{Kind: "dependency_visibility", Value: "none"},
 		},
 	}}, nil
+}
+
+func hasDependencyInventory(tool model.UnifiedTool) bool {
+	if tool.Metadata == nil {
+		return false
+	}
+	if repoURL := metadataString(tool.Metadata, "repo_url"); strings.TrimSpace(repoURL) != "" {
+		return true
+	}
+	deps, err := extractDependencies(tool)
+	return err == nil && len(deps) > 0
 }
 
 func metadataNote(meta map[string]any) string {

--- a/pkg/analyzer/dependency_inventory_test.go
+++ b/pkg/analyzer/dependency_inventory_test.go
@@ -42,6 +42,21 @@ func TestDependencyInventoryChecker_MCPWithDependencies_NoFinding(t *testing.T) 
 	assert.Empty(t, issues)
 }
 
+func TestDependencyInventoryChecker_MCPWithRepoURL_NoFinding(t *testing.T) {
+	checker := analyzer.NewDependencyInventoryChecker()
+	tool := model.UnifiedTool{
+		Name:     "safe_tool",
+		Protocol: model.ProtocolMCP,
+		Metadata: map[string]any{
+			"repo_url": "https://github.com/example/repo",
+		},
+	}
+
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
 func TestDependencyInventoryChecker_NonMCP_NoFinding(t *testing.T) {
 	checker := analyzer.NewDependencyInventoryChecker()
 	tool := model.UnifiedTool{

--- a/pkg/analyzer/dependency_visibility.go
+++ b/pkg/analyzer/dependency_visibility.go
@@ -1,0 +1,94 @@
+package analyzer
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
+)
+
+func DependencyVisibilityForTool(tool model.UnifiedTool) (visibility, note string) {
+	if tool.Metadata == nil {
+		return "No dependency data", "No metadata.dependencies or repo_url were exposed by this MCP server."
+	}
+
+	sources := dependencySourcesFromMetadata(tool.Metadata)
+	if len(sources) == 0 {
+		note = metadataString(tool.Metadata, "dependency_visibility_note")
+		if note == "" {
+			note = "No metadata.dependencies or repo_url were exposed by this MCP server."
+		}
+		return "No dependency data", note
+	}
+	return formatDependencyVisibility(sources), visibilityNote(tool.Metadata, sources)
+}
+
+func dependencySourcesFromMetadata(meta map[string]any) []string {
+	seen := map[string]bool{}
+	var sources []string
+
+	if raw, ok := meta["dependencies"]; ok {
+		b, err := json.Marshal(raw)
+		if err == nil {
+			var deps []struct {
+				Source string `json:"source"`
+			}
+			if err := json.Unmarshal(b, &deps); err == nil {
+				for _, dep := range deps {
+					source := dep.Source
+					if source == "" {
+						source = "metadata"
+					}
+					if !seen[source] {
+						seen[source] = true
+						sources = append(sources, source)
+					}
+				}
+			}
+		}
+	}
+
+	if repoURL, ok := meta["repo_url"].(string); ok && strings.TrimSpace(repoURL) != "" {
+		if !seen["repo_url"] {
+			sources = append(sources, "repo_url")
+		}
+	}
+
+	return sources
+}
+
+func visibilityNote(meta map[string]any, sources []string) string {
+	if note := metadataString(meta, "dependency_visibility_note"); note != "" {
+		return note
+	}
+	if len(sources) == 1 && sources[0] == "repo_url" {
+		return "repo_url is available, so ToolTrust can try to inspect remote lockfiles for dependency evidence."
+	}
+	return ""
+}
+
+func formatDependencyVisibility(sources []string) string {
+	labels := make([]string, 0, len(sources))
+	for _, source := range sources {
+		switch source {
+		case "metadata":
+			labels = append(labels, "Declared by MCP metadata")
+		case "local_lockfile":
+			labels = append(labels, "Verified from local lockfile")
+		case "lockfile":
+			labels = append(labels, "Verified from remote lockfile")
+		case "repo_url":
+			labels = append(labels, "Repo URL available")
+		default:
+			labels = append(labels, source)
+		}
+	}
+	return strings.Join(labels, " + ")
+}
+
+func metadataString(meta map[string]any, key string) string {
+	if value, ok := meta[key].(string); ok {
+		return value
+	}
+	return ""
+}

--- a/pkg/analyzer/dos.go
+++ b/pkg/analyzer/dos.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"strings"
 
+	"github.com/AgentSafe-AI/tooltrust-scanner/internal/jsonschema"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
 
@@ -82,13 +83,18 @@ func hasRateLimitSignal(tool model.UnifiedTool) bool {
 		}
 	}
 	// Check input schema property names
-	for propName := range tool.InputSchema.Properties {
-		propLower := strings.ToLower(propName)
+	found := false
+	tool.InputSchema.WalkProperties(func(ref jsonschema.PropertyRef) {
+		if found {
+			return
+		}
+		propLower := strings.ToLower(ref.Path)
 		for _, indicator := range rateLimitIndicators {
 			if strings.Contains(propLower, indicator) {
-				return true
+				found = true
+				return
 			}
 		}
-	}
-	return false
+	})
+	return found
 }

--- a/pkg/analyzer/dos_test.go
+++ b/pkg/analyzer/dos_test.go
@@ -95,3 +95,24 @@ func TestEngine_AS011_NetworkNoRateLimit(t *testing.T) {
 	report := eng_e6aadc.Scan(tool)
 	assert.True(t, report.HasFinding("AS-011"))
 }
+
+func TestDoSChecker_NestedTimeoutSchema_NoFinding(t *testing.T) {
+	tool := model.UnifiedTool{
+		Name:        "nested_http_client",
+		Permissions: []model.Permission{model.PermissionHTTP},
+		InputSchema: jsonschema.Schema{
+			Properties: map[string]jsonschema.Property{
+				"request": {
+					Type: "object",
+					Properties: map[string]jsonschema.Property{
+						"timeout_ms": {Type: "integer"},
+					},
+				},
+			},
+		},
+	}
+
+	issues, err := analyzer.NewDoSResilienceChecker().Check(tool)
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}

--- a/pkg/analyzer/export_test.go
+++ b/pkg/analyzer/export_test.go
@@ -17,6 +17,11 @@ func ParseRequirementsTxtForTest(data []byte) ([]Dependency, error) {
 	return parseRequirementsTxt(data)
 }
 
+// RawGitHubURLForTest exposes rawGitHubURL for unit tests.
+func RawGitHubURLForTest(repoURL, branch, filePath string) (string, bool) {
+	return rawGitHubURL(repoURL, branch, filePath)
+}
+
 // NewBlacklistCheckerWithDataForTest constructs a BlacklistChecker from custom
 // JSON for unit tests, bypassing the embedded blacklist.json.
 func NewBlacklistCheckerWithDataForTest(data []byte) (*BlacklistChecker, error) {

--- a/pkg/analyzer/npm_ioc.go
+++ b/pkg/analyzer/npm_ioc.go
@@ -123,15 +123,14 @@ func (c *NPMIOCChecker) Check(tool model.UnifiedTool) ([]model.Issue, error) {
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), npmQueryTimeout)
-	defer cancel()
-
 	var issues []model.Issue
 	for _, dep := range deps {
 		if !strings.EqualFold(dep.Ecosystem, "npm") {
 			continue
 		}
-		meta, err := c.client.FetchVersion(ctx, dep.Name, dep.Version)
+		queryCtx, cancel := context.WithTimeout(context.Background(), npmQueryTimeout)
+		meta, err := c.client.FetchVersion(queryCtx, dep.Name, dep.Version)
+		cancel()
 		if err != nil {
 			continue
 		}

--- a/pkg/analyzer/npm_registry_decode_test.go
+++ b/pkg/analyzer/npm_registry_decode_test.go
@@ -1,0 +1,34 @@
+package analyzer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPNPMRegistryClient_AllowsBooleanBundleDependencies(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name": "demo",
+			"version": "1.0.0",
+			"scripts": {"postinstall": "node install.js"},
+			"bundleDependencies": false
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &httpNPMRegistryClient{
+		http:    server.Client(),
+		baseURL: server.URL,
+	}
+
+	got, err := client.FetchVersion(context.Background(), "demo", "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "node install.js", got.Scripts["postinstall"])
+	assert.Empty(t, got.BundleDependencies)
+}

--- a/pkg/analyzer/npm_scripts.go
+++ b/pkg/analyzer/npm_scripts.go
@@ -14,8 +14,9 @@ import (
 
 const (
 	npmRegistryVersionURL = "https://registry.npmjs.org"
-	npmQueryTimeout       = 8 * time.Second
 )
+
+var npmQueryTimeout = 8 * time.Second
 
 var suspiciousNPMScriptKeys = []string{
 	"preinstall",
@@ -140,15 +141,14 @@ func (c *NPMLifecycleScriptChecker) Check(tool model.UnifiedTool) ([]model.Issue
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), npmQueryTimeout)
-	defer cancel()
-
 	var issues []model.Issue
 	for _, dep := range deps {
 		if !strings.EqualFold(dep.Ecosystem, "npm") {
 			continue
 		}
-		meta, err := c.client.FetchVersion(ctx, dep.Name, dep.Version)
+		queryCtx, cancel := context.WithTimeout(context.Background(), npmQueryTimeout)
+		meta, err := c.client.FetchVersion(queryCtx, dep.Name, dep.Version)
+		cancel()
 		if err != nil {
 			continue
 		}

--- a/pkg/analyzer/npm_scripts.go
+++ b/pkg/analyzer/npm_scripts.go
@@ -47,6 +47,77 @@ type npmVersionResponse struct {
 	BundledDependencies  []string          `json:"bundledDependencies"`
 }
 
+func (r *npmVersionResponse) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Name                 string            `json:"name"`
+		Version              string            `json:"version"`
+		Scripts              map[string]string `json:"scripts"`
+		Dependencies         map[string]string `json:"dependencies"`
+		OptionalDependencies map[string]string `json:"optionalDependencies"`
+		BundleDependencies   json.RawMessage   `json:"bundleDependencies"`
+		BundledDependencies  json.RawMessage   `json:"bundledDependencies"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+
+	bundleDeps, err := decodeNPMStringList(wire.BundleDependencies, "bundleDependencies")
+	if err != nil {
+		return err
+	}
+	bundledDeps, err := decodeNPMStringList(wire.BundledDependencies, "bundledDependencies")
+	if err != nil {
+		return err
+	}
+
+	*r = npmVersionResponse{
+		Name:                 wire.Name,
+		Version:              wire.Version,
+		Scripts:              wire.Scripts,
+		Dependencies:         wire.Dependencies,
+		OptionalDependencies: wire.OptionalDependencies,
+		BundleDependencies:   bundleDeps,
+		BundledDependencies:  bundledDeps,
+	}
+	return nil
+}
+
+func decodeNPMStringList(raw json.RawMessage, field string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var out []string
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return nil, fmt.Errorf("npm: decode %s: %w", field, err)
+		}
+		return out, nil
+	case '"':
+		var one string
+		if err := json.Unmarshal(raw, &one); err != nil {
+			return nil, fmt.Errorf("npm: decode %s: %w", field, err)
+		}
+		if strings.TrimSpace(one) == "" {
+			return nil, nil
+		}
+		return []string{one}, nil
+	case 't', 'f':
+		var enabled bool
+		if err := json.Unmarshal(raw, &enabled); err != nil {
+			return nil, fmt.Errorf("npm: decode %s: %w", field, err)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("npm: decode %s: unsupported JSON value %s", field, trimmed)
+	}
+}
+
 type npmRegistryClient interface {
 	FetchVersion(ctx context.Context, pkg, version string) (npmVersionResponse, error)
 }

--- a/pkg/analyzer/permission.go
+++ b/pkg/analyzer/permission.go
@@ -54,7 +54,7 @@ func (c *PermissionChecker) Check(tool model.UnifiedTool) ([]model.Issue, error)
 		})
 	}
 
-	if propCount := len(tool.InputSchema.Properties); propCount > largeSchemaPropThreshold {
+	if propCount := tool.InputSchema.PropertyCount(); propCount > largeSchemaPropThreshold {
 		issues = append(issues, model.Issue{
 			RuleID:      "AS-002",
 			ToolName:    tool.Name,

--- a/pkg/analyzer/permission_test.go
+++ b/pkg/analyzer/permission_test.go
@@ -80,3 +80,33 @@ func TestPermissionChecker_SchemaPropCountNote(t *testing.T) {
 	}
 	assert.True(t, found, "expected LARGE_INPUT_SURFACE issue for schemas with >10 properties")
 }
+
+func TestPermissionChecker_CountsNestedSchemaProps(t *testing.T) {
+	nested := map[string]jsonschema.Property{}
+	for i := range 11 {
+		nested[string(rune('a'+i))] = jsonschema.Property{Type: "string"}
+	}
+
+	tool := model.UnifiedTool{
+		InputSchema: jsonschema.Schema{
+			Properties: map[string]jsonschema.Property{
+				"request": {
+					Type:       "object",
+					Properties: nested,
+				},
+			},
+		},
+	}
+
+	issues, err := analyzer.NewPermissionChecker().Check(tool)
+	require.NoError(t, err)
+
+	var found bool
+	for _, issue := range issues {
+		if issue.Code == "LARGE_INPUT_SURFACE" {
+			found = true
+			assert.Equal(t, "12", issue.Evidence[0].Value)
+		}
+	}
+	assert.True(t, found, "expected nested schema properties to count toward LARGE_INPUT_SURFACE")
+}

--- a/pkg/analyzer/secrets.go
+++ b/pkg/analyzer/secrets.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AgentSafe-AI/tooltrust-scanner/internal/jsonschema"
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
 
@@ -72,10 +73,14 @@ func (c *SecretHandlingChecker) Check(tool model.UnifiedTool) ([]model.Issue, er
 	var issues []model.Issue
 
 	// 1. Input schema: look for parameter names that indicate secrets
-	for propName := range tool.InputSchema.Properties {
-		nameLower := strings.ToLower(propName)
-		if secretParamAllowlist[nameLower] {
-			continue
+	tool.InputSchema.WalkProperties(func(ref jsonschema.PropertyRef) {
+		nameLower := strings.ToLower(ref.Path)
+		baseName := nameLower
+		if idx := strings.LastIndex(baseName, "."); idx >= 0 {
+			baseName = baseName[idx+1:]
+		}
+		if secretParamAllowlist[nameLower] || secretParamAllowlist[baseName] {
+			return
 		}
 		for _, pattern := range secretParamPatterns {
 			if nameLower == pattern || strings.Contains(nameLower, pattern) {
@@ -84,13 +89,13 @@ func (c *SecretHandlingChecker) Check(tool model.UnifiedTool) ([]model.Issue, er
 					ToolName:    tool.Name,
 					Severity:    model.SeverityHigh,
 					Code:        "SECRET_IN_INPUT",
-					Description: fmt.Sprintf("input parameter %q appears to accept a secret or credential", propName),
-					Location:    fmt.Sprintf("inputSchema.properties.%s", propName),
+					Description: fmt.Sprintf("input parameter %q appears to accept a secret or credential", ref.Path),
+					Location:    fmt.Sprintf("inputSchema.properties.%s", ref.Path),
 				})
 				break
 			}
 		}
-	}
+	})
 
 	// 2. Description: look for insecure secret handling language
 	descLower := strings.ToLower(tool.Description)

--- a/pkg/analyzer/secrets_test.go
+++ b/pkg/analyzer/secrets_test.go
@@ -143,3 +143,24 @@ func TestEngine_AS010_SecretParam(t *testing.T) {
 	report := eng_936989.Scan(tool)
 	assert.True(t, report.HasFinding("AS-010"))
 }
+
+func TestSecretChecker_NestedSecretParam_Finding(t *testing.T) {
+	tool := model.UnifiedTool{
+		Name: "nested_creds_tool",
+		InputSchema: jsonschema.Schema{
+			Properties: map[string]jsonschema.Property{
+				"auth": {
+					Type: "object",
+					Properties: map[string]jsonschema.Property{
+						"client_secret": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	issues, err := analyzer.NewSecretHandlingChecker().Check(tool)
+	require.NoError(t, err)
+	require.NotEmpty(t, issues)
+	assert.Contains(t, issues[0].Location, "auth.client_secret")
+}

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -490,13 +491,32 @@ func fetchLockfileDeps(repoURL string) []Dependency {
 // rawGitHubURL converts a github.com URL to raw.githubusercontent.com for
 // the given branch and file path.  Returns ("", false) for non-GitHub URLs.
 func rawGitHubURL(repoURL, branch, filePath string) (string, bool) {
-	clean := strings.TrimSuffix(strings.TrimSpace(repoURL), ".git")
-	clean = strings.TrimPrefix(clean, "git+")
-	if !strings.Contains(clean, "github.com/") {
+	clean := strings.TrimPrefix(strings.TrimSpace(repoURL), "git+")
+	parsed, err := url.Parse(clean)
+	if err != nil {
 		return "", false
 	}
-	raw := strings.Replace(clean, "github.com/", "raw.githubusercontent.com/", 1)
-	return fmt.Sprintf("%s/%s/%s", raw, branch, filePath), true
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return "", false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host != "github.com" && host != "www.github.com" {
+		return "", false
+	}
+
+	repoPath := strings.Trim(parsed.Path, "/")
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+	parts := strings.Split(repoPath, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", false
+	}
+
+	branch = strings.Trim(branch, "/")
+	filePath = strings.TrimPrefix(strings.ReplaceAll(filePath, "\\", "/"), "/")
+	if branch == "" || filePath == "" {
+		return "", false
+	}
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", parts[0], parts[1], branch, filePath), true
 }
 
 // mergeDependencies merges two dep slices, deduplicating by ecosystem+name+version.

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -19,11 +19,11 @@ import (
 
 const (
 	osvAPIURL          = "https://api.osv.dev/v1/query"
-	osvQueryTimeout    = 10 * time.Second
-	osvTotalTimeout    = 30 * time.Second
 	lockfileFetchLimit = 5 << 20 // 5 MB per lockfile
 	maxOSVConcurrency  = 5
 )
+
+var osvQueryTimeout = 10 * time.Second
 
 // ── Data types ────────────────────────────────────────────────────────────────
 
@@ -365,44 +365,77 @@ func parseYarnLock(data []byte) ([]Dependency, error) {
 		if line == "" || strings.HasPrefix(line, "#") || !strings.HasSuffix(line, ":") {
 			continue
 		}
-		if strings.Contains(line, " version ") {
+		header := strings.TrimSuffix(line, ":")
+		if header == "__metadata" || strings.Contains(line, " version ") {
 			continue
 		}
+		version := ""
 
 		for j := i + 1; j < len(lines); j++ {
+			if !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t") {
+				break
+			}
 			next := strings.TrimSpace(lines[j])
 			if next == "" {
 				break
 			}
-			if strings.HasPrefix(next, "version ") {
-				version := strings.Trim(next[len("version "):], "\"")
-				specs := strings.Split(strings.TrimSuffix(line, ":"), ",")
-				for _, spec := range specs {
-					spec = strings.Trim(strings.TrimSpace(spec), "\"")
-					if spec == "" {
-						continue
-					}
-					idx := strings.LastIndex(spec, "@")
-					if idx <= 0 || idx == len(spec)-1 {
-						continue
-					}
-					name := spec[:idx]
-					k := name + "@" + version
-					if seen[k] {
-						continue
-					}
-					seen[k] = true
-					deps = append(deps, Dependency{Name: name, Version: version, Ecosystem: "npm"})
-				}
+			switch {
+			case strings.HasPrefix(next, "version "):
+				version = strings.Trim(strings.TrimSpace(next[len("version "):]), "\"'")
+			case strings.HasPrefix(next, "version:"):
+				version = strings.Trim(strings.TrimSpace(next[len("version:"):]), "\"'")
+			}
+			if version != "" {
 				break
 			}
-			if !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t") {
-				break
+		}
+		if version == "" {
+			continue
+		}
+		specs := strings.Split(header, ",")
+		for _, spec := range specs {
+			spec = strings.Trim(strings.TrimSpace(spec), "\"'")
+			if spec == "" {
+				continue
 			}
+			name, ok := parseYarnPackageName(spec)
+			if !ok {
+				continue
+			}
+			k := name + "@" + version
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			deps = append(deps, Dependency{Name: name, Version: version, Ecosystem: "npm"})
 		}
 	}
 
 	return deps, nil
+}
+
+func parseYarnPackageName(spec string) (string, bool) {
+	spec = strings.TrimSpace(strings.Trim(spec, "\"'"))
+	if spec == "" {
+		return "", false
+	}
+	if strings.HasPrefix(spec, "@") {
+		slash := strings.Index(spec, "/")
+		if slash < 0 {
+			return "", false
+		}
+		rest := spec[slash+1:]
+		at := strings.Index(rest, "@")
+		if at < 0 {
+			return "", false
+		}
+		return spec[:slash+1+at], true
+	}
+	at := strings.Index(spec, "@")
+	if at <= 0 {
+		return "", false
+	}
+	return spec[:at], true
 }
 
 // fetchLockfileDeps fetches and parses lockfiles from a GitHub repository URL.
@@ -522,9 +555,6 @@ func (c *SupplyChainChecker) Check(tool model.UnifiedTool) ([]model.Issue, error
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), osvTotalTimeout)
-	defer cancel()
-
 	// Query OSV in parallel (capped at maxOSVConcurrency goroutines).
 	ch := make(chan []model.Issue, len(deps))
 	sem := make(chan struct{}, maxOSVConcurrency)
@@ -538,7 +568,10 @@ func (c *SupplyChainChecker) Check(tool model.UnifiedTool) ([]model.Issue, error
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			vulns, qErr := c.client.Query(ctx, dep.Dependency)
+			queryCtx, cancel := context.WithTimeout(context.Background(), osvQueryTimeout)
+			defer cancel()
+
+			vulns, qErr := c.client.Query(queryCtx, dep.Dependency)
 			if qErr != nil {
 				ch <- nil
 				return

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -302,7 +302,7 @@ func parseRequirementsTxt(data []byte) ([]Dependency, error) {
 		}
 		// Only exact pins (==) are meaningful for CVE lookup
 		if idx := strings.Index(line, "=="); idx > 0 {
-			name := strings.TrimSpace(line[:idx])
+			name := normalizePythonPackageName(strings.TrimSpace(line[:idx]))
 			version := strings.TrimSpace(line[idx+2:])
 			if name != "" && version != "" {
 				deps = append(deps, Dependency{Name: name, Version: version, Ecosystem: "PyPI"})
@@ -313,6 +313,13 @@ func parseRequirementsTxt(data []byte) ([]Dependency, error) {
 		return nil, fmt.Errorf("parse requirements.txt: %w", err)
 	}
 	return deps, nil
+}
+
+func normalizePythonPackageName(name string) string {
+	if idx := strings.IndexByte(name, '['); idx >= 0 {
+		name = name[:idx]
+	}
+	return strings.TrimSpace(name)
 }
 
 type pnpmLockfile struct {

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -315,15 +315,23 @@ func parseRequirementsTxt(data []byte) ([]Dependency, error) {
 func splitPythonExactPin(line string) (name, version string, ok bool) {
 	if idx := strings.Index(line, "==="); idx > 0 {
 		name = normalizePythonPackageName(strings.TrimSpace(line[:idx]))
-		version = strings.TrimSpace(line[idx+3:])
+		version = normalizePythonPackageVersion(line[idx+3:])
 		return name, version, name != "" && version != ""
 	}
 	if idx := strings.Index(line, "=="); idx > 0 {
 		name = normalizePythonPackageName(strings.TrimSpace(line[:idx]))
-		version = strings.TrimSpace(line[idx+2:])
+		version = normalizePythonPackageVersion(line[idx+2:])
 		return name, version, name != "" && version != ""
 	}
 	return "", "", false
+}
+
+func normalizePythonPackageVersion(version string) string {
+	fields := strings.Fields(strings.TrimSpace(version))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.TrimSuffix(fields[0], "\\")
 }
 
 func normalizePythonPackageName(name string) string {

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -39,6 +39,7 @@ type Dependency struct {
 	Name      string `json:"name"`
 	Version   string `json:"version"`
 	Ecosystem string `json:"ecosystem"` // e.g. "npm", "Go", "PyPI"
+	Source    string `json:"source,omitempty"`
 }
 
 type dependencyEvidence struct {
@@ -697,9 +698,13 @@ func collectDependencies(tool model.UnifiedTool) ([]dependencyEvidence, error) {
 			continue
 		}
 		seen[k] = true
+		source := dep.Source
+		if source == "" {
+			source = "metadata"
+		}
 		result = append(result, dependencyEvidence{
 			Dependency: dep,
-			Source:     "metadata",
+			Source:     source,
 		})
 	}
 

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -715,8 +717,8 @@ func osvSeverityToModel(v osvVuln) model.Severity {
 }
 
 func cvssScoreToSeverity(score string) model.Severity {
-	var f float64
-	if _, err := fmt.Sscanf(score, "%f", &f); err != nil {
+	f, ok := parseCVSSScore(score)
+	if !ok {
 		return model.SeverityHigh
 	}
 	switch {
@@ -729,4 +731,111 @@ func cvssScoreToSeverity(score string) model.Severity {
 	default:
 		return model.SeverityLow
 	}
+}
+
+func parseCVSSScore(score string) (float64, bool) {
+	score = strings.TrimSpace(score)
+	if score == "" {
+		return 0, false
+	}
+	if f, err := strconv.ParseFloat(score, 64); err == nil {
+		return f, true
+	}
+	if strings.HasPrefix(score, "CVSS:3.") {
+		return cvssV3BaseScore(score)
+	}
+	return 0, false
+}
+
+func cvssV3BaseScore(vector string) (float64, bool) {
+	metrics := parseCVSSVector(vector)
+	scope := metrics["S"]
+	av, ok := mapMetric(metrics["AV"], map[string]float64{"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2})
+	if !ok {
+		return 0, false
+	}
+	ac, ok := mapMetric(metrics["AC"], map[string]float64{"L": 0.77, "H": 0.44})
+	if !ok {
+		return 0, false
+	}
+	pr, ok := cvssPrivilegeRequired(metrics["PR"], scope)
+	if !ok {
+		return 0, false
+	}
+	ui, ok := mapMetric(metrics["UI"], map[string]float64{"N": 0.85, "R": 0.62})
+	if !ok {
+		return 0, false
+	}
+	conf, ok := mapMetric(metrics["C"], map[string]float64{"H": 0.56, "L": 0.22, "N": 0})
+	if !ok {
+		return 0, false
+	}
+	integrity, ok := mapMetric(metrics["I"], map[string]float64{"H": 0.56, "L": 0.22, "N": 0})
+	if !ok {
+		return 0, false
+	}
+	avail, ok := mapMetric(metrics["A"], map[string]float64{"H": 0.56, "L": 0.22, "N": 0})
+	if !ok {
+		return 0, false
+	}
+
+	impactSubScore := 1 - ((1 - conf) * (1 - integrity) * (1 - avail))
+	var impact float64
+	switch scope {
+	case "U":
+		impact = 6.42 * impactSubScore
+	case "C":
+		impact = 7.52*(impactSubScore-0.029) - 3.25*math.Pow(impactSubScore-0.02, 15)
+	default:
+		return 0, false
+	}
+	if impact <= 0 {
+		return 0, true
+	}
+
+	exploitability := 8.22 * av * ac * pr * ui
+	if scope == "C" {
+		return roundUp1(math.Min(1.08*(impact+exploitability), 10)), true
+	}
+	return roundUp1(math.Min(impact+exploitability, 10)), true
+}
+
+func parseCVSSVector(vector string) map[string]string {
+	out := map[string]string{}
+	for _, part := range strings.Split(vector, "/") {
+		key, value, ok := strings.Cut(part, ":")
+		if !ok || key == "CVSS" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func mapMetric(value string, weights map[string]float64) (float64, bool) {
+	f, ok := weights[value]
+	return f, ok
+}
+
+func cvssPrivilegeRequired(value, scope string) (float64, bool) {
+	switch value {
+	case "N":
+		return 0.85, true
+	case "L":
+		if scope == "C" {
+			return 0.68, true
+		}
+		return 0.62, scope == "U"
+	case "H":
+		if scope == "C" {
+			return 0.5, true
+		}
+		return 0.27, scope == "U"
+	default:
+		return 0, false
+	}
+}
+
+func roundUp1(f float64) float64 {
+	return math.Ceil(f*10) / 10
 }

--- a/pkg/analyzer/supply_chain.go
+++ b/pkg/analyzer/supply_chain.go
@@ -300,19 +300,30 @@ func parseRequirementsTxt(data []byte) ([]Dependency, error) {
 		if i := strings.IndexByte(line, ';'); i >= 0 {
 			line = strings.TrimSpace(line[:i])
 		}
-		// Only exact pins (==) are meaningful for CVE lookup
-		if idx := strings.Index(line, "=="); idx > 0 {
-			name := normalizePythonPackageName(strings.TrimSpace(line[:idx]))
-			version := strings.TrimSpace(line[idx+2:])
-			if name != "" && version != "" {
-				deps = append(deps, Dependency{Name: name, Version: version, Ecosystem: "PyPI"})
-			}
+		// Only exact pins are meaningful for CVE lookup.
+		name, version, ok := splitPythonExactPin(line)
+		if ok {
+			deps = append(deps, Dependency{Name: name, Version: version, Ecosystem: "PyPI"})
 		}
 	}
 	if err := sc.Err(); err != nil {
 		return nil, fmt.Errorf("parse requirements.txt: %w", err)
 	}
 	return deps, nil
+}
+
+func splitPythonExactPin(line string) (name, version string, ok bool) {
+	if idx := strings.Index(line, "==="); idx > 0 {
+		name = normalizePythonPackageName(strings.TrimSpace(line[:idx]))
+		version = strings.TrimSpace(line[idx+3:])
+		return name, version, name != "" && version != ""
+	}
+	if idx := strings.Index(line, "=="); idx > 0 {
+		name = normalizePythonPackageName(strings.TrimSpace(line[:idx]))
+		version = strings.TrimSpace(line[idx+2:])
+		return name, version, name != "" && version != ""
+	}
+	return "", "", false
 }
 
 func normalizePythonPackageName(name string) string {

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -346,11 +346,12 @@ func TestParseRequirementsTxt(t *testing.T) {
 django==4.2.0
 requests>=2.28.0
 Flask==2.3.1 ; python_requires >= "3.8"
+requests[security]==2.32.0
 -r other.txt
 `)
 	deps, err := analyzer.ParseRequirementsTxtForTest(data)
 	require.NoError(t, err)
-	assert.Len(t, deps, 2, "only exact == pins and no -r lines")
+	assert.Len(t, deps, 3, "only exact == pins and no -r lines")
 
 	names := make(map[string]string)
 	for _, d := range deps {
@@ -359,6 +360,7 @@ Flask==2.3.1 ; python_requires >= "3.8"
 	}
 	assert.Equal(t, "4.2.0", names["django"])
 	assert.Equal(t, "2.3.1", names["Flask"])
+	assert.Equal(t, "2.32.0", names["requests"])
 }
 
 func TestParsePNPMLockYAML(t *testing.T) {

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -402,3 +402,14 @@ __metadata:
 	assert.Equal(t, "1.14.1", names["axios"])
 	assert.Equal(t, "2.3.4", names["@scope/sdk"])
 }
+
+func TestRawGitHubURL_RejectsNonGitHubHostContainingGitHubPath(t *testing.T) {
+	_, ok := analyzer.RawGitHubURLForTest("https://evil.example/github.com/owner/repo", "main", "package-lock.json")
+	assert.False(t, ok)
+}
+
+func TestRawGitHubURL_NormalizesTrailingSlashAndGitSuffix(t *testing.T) {
+	got, ok := analyzer.RawGitHubURLForTest("https://github.com/owner/repo.git/", "main", "package-lock.json")
+	require.True(t, ok)
+	assert.Equal(t, "https://raw.githubusercontent.com/owner/repo/main/package-lock.json", got)
+}

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -359,3 +359,27 @@ func TestParseYarnLock(t *testing.T) {
 	assert.Equal(t, "1.14.1", names["axios"])
 	assert.Equal(t, "2.3.4", names["@scope/sdk"])
 }
+
+func TestParseYarnLock_YarnBerry(t *testing.T) {
+	data := []byte(`
+__metadata:
+  version: 8
+
+"axios@npm:^1.14.1":
+  version: 1.14.1
+
+"@scope/sdk@npm:^2.3.4":
+  version: 2.3.4
+`)
+	deps, err := analyzer.ParseYarnLockForTest(data)
+	require.NoError(t, err)
+	assert.Len(t, deps, 2)
+
+	names := make(map[string]string)
+	for _, d := range deps {
+		names[d.Name] = d.Version
+		assert.Equal(t, "npm", d.Ecosystem)
+	}
+	assert.Equal(t, "1.14.1", names["axios"])
+	assert.Equal(t, "2.3.4", names["@scope/sdk"])
+}

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -86,6 +86,25 @@ func TestSupplyChainChecker_CVEFound_CriticalScore(t *testing.T) {
 	assert.Contains(t, issues[0].Description, "lodash@4.17.15")
 }
 
+func TestSupplyChainChecker_CVEFound_CriticalCVSSVector(t *testing.T) {
+	checker := analyzer.NewSupplyChainCheckerWithMock([]analyzer.MockVuln{
+		{ID: "CVE-2024-1234", Summary: "Remote code execution", CVSSScore: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+	}, nil)
+
+	tool := model.UnifiedTool{
+		Name: "vuln_tool",
+		Metadata: map[string]any{
+			"dependencies": []any{
+				map[string]any{"name": "lodash", "version": "4.17.15", "ecosystem": "npm"},
+			},
+		},
+	}
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, model.SeverityCritical, issues[0].Severity)
+}
+
 func TestSupplyChainChecker_CVEFound_HighScore(t *testing.T) {
 	checker := analyzer.NewSupplyChainCheckerWithMock([]analyzer.MockVuln{
 		{ID: "CVE-2023-5678", Summary: "Privilege escalation", CVSSScore: "7.5"},

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -348,11 +348,14 @@ requests>=2.28.0
 Flask==2.3.1 ; python_requires >= "3.8"
 requests[security]==2.32.0
 urllib3===2.0.0
+certifi==2024.2.2 --hash=sha256:abc123
+idna==3.6 \
+    --hash=sha256:def456
 -r other.txt
 `)
 	deps, err := analyzer.ParseRequirementsTxtForTest(data)
 	require.NoError(t, err)
-	assert.Len(t, deps, 4, "only exact pins and no -r lines")
+	assert.Len(t, deps, 6, "only exact pins and no -r lines")
 
 	names := make(map[string]string)
 	for _, d := range deps {
@@ -363,6 +366,8 @@ urllib3===2.0.0
 	assert.Equal(t, "2.3.1", names["Flask"])
 	assert.Equal(t, "2.32.0", names["requests"])
 	assert.Equal(t, "2.0.0", names["urllib3"])
+	assert.Equal(t, "2024.2.2", names["certifi"])
+	assert.Equal(t, "3.6", names["idna"])
 }
 
 func TestParsePNPMLockYAML(t *testing.T) {

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -347,11 +347,12 @@ django==4.2.0
 requests>=2.28.0
 Flask==2.3.1 ; python_requires >= "3.8"
 requests[security]==2.32.0
+urllib3===2.0.0
 -r other.txt
 `)
 	deps, err := analyzer.ParseRequirementsTxtForTest(data)
 	require.NoError(t, err)
-	assert.Len(t, deps, 3, "only exact == pins and no -r lines")
+	assert.Len(t, deps, 4, "only exact pins and no -r lines")
 
 	names := make(map[string]string)
 	for _, d := range deps {
@@ -361,6 +362,7 @@ requests[security]==2.32.0
 	assert.Equal(t, "4.2.0", names["django"])
 	assert.Equal(t, "2.3.1", names["Flask"])
 	assert.Equal(t, "2.32.0", names["requests"])
+	assert.Equal(t, "2.0.0", names["urllib3"])
 }
 
 func TestParsePNPMLockYAML(t *testing.T) {

--- a/pkg/analyzer/supply_chain_test.go
+++ b/pkg/analyzer/supply_chain_test.go
@@ -272,6 +272,32 @@ func TestSupplyChainChecker_RepoURLLockfileDependency_IncludesEvidenceSource(t *
 	assert.Equal(t, "MALICIOUS_PACKAGE", issues[0].Code)
 }
 
+func TestSupplyChainChecker_MetadataDependency_PreservesEvidenceSource(t *testing.T) {
+	checker := analyzer.NewSupplyChainCheckerWithMock([]analyzer.MockVuln{
+		{ID: "CVE-2026-1234", Summary: "Remote code execution", CVSSScore: "9.8"},
+	}, nil)
+
+	tool := model.UnifiedTool{
+		Name: "metadata_tool",
+		Metadata: map[string]any{
+			"dependencies": []map[string]any{
+				{
+					"name":      "axios",
+					"version":   "1.14.1",
+					"ecosystem": "npm",
+					"source":    "local_lockfile",
+				},
+			},
+		},
+	}
+
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "dependency_source", issues[0].Evidence[3].Kind)
+	assert.Equal(t, "local_lockfile", issues[0].Evidence[3].Value)
+}
+
 // ---------------------------------------------------------------------------
 // Lockfile parser unit tests
 // ---------------------------------------------------------------------------

--- a/pkg/analyzer/timeout_regression_test.go
+++ b/pkg/analyzer/timeout_regression_test.go
@@ -1,0 +1,121 @@
+package analyzer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
+)
+
+type slowFirstOSVClient struct{}
+
+func (slowFirstOSVClient) Query(ctx context.Context, dep Dependency) ([]osvVuln, error) {
+	if dep.Name == "slowpkg" {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return []osvVuln{{
+		ID:      "GHSA-fast-1234",
+		Summary: "fast dependency should still be checked",
+	}}, nil
+}
+
+type slowFirstNPMClient struct{}
+
+func (slowFirstNPMClient) FetchVersion(ctx context.Context, pkg, version string) (npmVersionResponse, error) {
+	if pkg == "slowpkg" {
+		<-ctx.Done()
+		return npmVersionResponse{}, ctx.Err()
+	}
+	return npmVersionResponse{
+		Name:    pkg,
+		Version: version,
+		Scripts: map[string]string{"postinstall": "node install.js"},
+		Dependencies: map[string]string{
+			"plain-crypto-js": "^0.4.2",
+		},
+	}, nil
+}
+
+func TestSupplyChainChecker_PerDependencyTimeoutKeepsScanning(t *testing.T) {
+	prev := osvQueryTimeout
+	osvQueryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { osvQueryTimeout = prev })
+
+	checker := newSupplyChainCheckerWithClient(slowFirstOSVClient{})
+	tool := model.UnifiedTool{
+		Name: "deploy_site",
+		Metadata: map[string]any{
+			"dependencies": []any{
+				map[string]any{"name": "slowpkg", "version": "1.0.0", "ecosystem": "npm"},
+				map[string]any{"name": "fastpkg", "version": "2.0.0", "ecosystem": "npm"},
+			},
+		},
+	}
+
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0].Description, "fastpkg@2.0.0")
+}
+
+func TestNPMLifecycleScriptChecker_PerDependencyTimeoutKeepsScanning(t *testing.T) {
+	prev := npmQueryTimeout
+	npmQueryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { npmQueryTimeout = prev })
+
+	checker := &NPMLifecycleScriptChecker{client: slowFirstNPMClient{}}
+	tool := model.UnifiedTool{
+		Name: "deploy_site",
+		Metadata: map[string]any{
+			"dependencies": []any{
+				map[string]any{"name": "slowpkg", "version": "1.0.0", "ecosystem": "npm"},
+				map[string]any{"name": "fastpkg", "version": "2.0.0", "ecosystem": "npm"},
+			},
+		},
+	}
+
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0].Description, "fastpkg@2.0.0")
+}
+
+func TestNPMIOCChecker_PerDependencyTimeoutKeepsScanning(t *testing.T) {
+	prev := npmQueryTimeout
+	npmQueryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { npmQueryTimeout = prev })
+
+	checker := &NPMIOCChecker{
+		client: slowFirstNPMClient{},
+		index: npmIOCIndex{
+			packageNames: map[string]npmIOCEntry{
+				"plain-crypto-js": {
+					Ecosystem:  "npm",
+					IOCType:    "package_name",
+					Value:      "plain-crypto-js",
+					Reason:     "Known malicious package",
+					Confidence: "high",
+				},
+			},
+		},
+	}
+	tool := model.UnifiedTool{
+		Name: "deploy_site",
+		Metadata: map[string]any{
+			"dependencies": []any{
+				map[string]any{"name": "slowpkg", "version": "1.0.0", "ecosystem": "npm"},
+				map[string]any{"name": "fastpkg", "version": "2.0.0", "ecosystem": "npm"},
+			},
+		},
+	}
+
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0].Description, "fastpkg@2.0.0")
+}

--- a/pkg/deepscan/manager.go
+++ b/pkg/deepscan/manager.go
@@ -18,6 +18,8 @@ import (
 	"github.com/sugarme/tokenizer"
 	"github.com/sugarme/tokenizer/pretrained"
 	"github.com/yalue/onnxruntime_go"
+
+	"github.com/AgentSafe-AI/tooltrust-scanner/internal/userhome"
 )
 
 // Real ONNX and tokenizer URLs for Phase 3 (all-MiniLM-L6-v2 quantized).
@@ -150,7 +152,7 @@ func getONNXSharedLibraryPath() string {
 // EnsureModels downloads the required ONNX and tokenizer files if they don't exist.
 // Returns the absolute paths to the model and tokenizer, or an error.
 func EnsureModels(ctx context.Context) (modelPath, tokenizerPath string, err error) {
-	home, err := os.UserHomeDir()
+	home, err := userhome.Resolve()
 	if err != nil {
 		return "", "", fmt.Errorf("unable to determine user home directory: %w", err)
 	}

--- a/pkg/sourcedetect/detector.go
+++ b/pkg/sourcedetect/detector.go
@@ -1,7 +1,6 @@
 package sourcedetect
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,8 +10,6 @@ import (
 
 	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
 )
-
-var errStopWalk = errors.New("tooltrust-stop-walk")
 
 func DetectEmbeddedMCP(root string, opts Options) (*DetectionResult, error) {
 	if strings.TrimSpace(root) == "" {
@@ -80,15 +77,12 @@ func DetectEmbeddedMCP(root string, opts Options) (*DetectionResult, error) {
 					Value: fmt.Sprintf("%s:%d", rel, ev.Line),
 				})
 			}
-			if matchCountByLanguage[sig.Language] >= opts.MaxMatchesPerLanguage {
-				return errStopWalk
-			}
 			break
 		}
 
 		return nil
 	})
-	if err != nil && !errors.Is(err, errStopWalk) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/sourcedetect/detector_test.go
+++ b/pkg/sourcedetect/detector_test.go
@@ -1,6 +1,7 @@
 package sourcedetect
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,6 +34,42 @@ func TestDetectEmbeddedMCP_PositiveFixtures(t *testing.T) {
 	}
 }
 
+func TestDetectEmbeddedMCP_GoMark3LabsServer(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "server.go"), []byte(`
+package main
+
+import "github.com/mark3labs/mcp-go/server"
+
+func main() {
+	srv := server.NewMCPServer("demo", "1.0.0")
+	srv.AddTool(buildTool(), handleTool)
+}
+`), 0o644))
+
+	got, err := DetectEmbeddedMCP(root, Options{})
+	require.NoError(t, err)
+	require.True(t, got.HasEmbeddedMCP)
+	require.NotEmpty(t, got.Detection.Matches)
+	assert.Equal(t, "go", got.Detection.Matches[0].Language)
+}
+
+func TestDetectEmbeddedMCP_CommonJSFile(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "server.cjs"), []byte(`
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+
+const server = new McpServer({ name: "demo", version: "1.0.0" });
+server.registerTool("demo", {}, async () => ({}));
+`), 0o644))
+
+	got, err := DetectEmbeddedMCP(root, Options{})
+	require.NoError(t, err)
+	require.True(t, got.HasEmbeddedMCP)
+	require.NotEmpty(t, got.Detection.Matches)
+	assert.Equal(t, "typescript", got.Detection.Matches[0].Language)
+}
+
 func TestDetectEmbeddedMCP_CoOccurrenceRequired(t *testing.T) {
 	cases := []string{"go-import-only", "go-init-only"}
 	for _, fixture := range cases {
@@ -54,4 +91,32 @@ func TestDetectEmbeddedMCP_SkipAndIgnoreRules(t *testing.T) {
 			assert.False(t, got.HasEmbeddedMCP)
 		})
 	}
+}
+
+func TestDetectEmbeddedMCP_MaxMatchesPerLanguageDoesNotHideOtherLanguages(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "server.go"), []byte(`
+package main
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func main() {
+	_ = mcp.NewServer("demo", "1.0.0")
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "server.py"), []byte(`
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("demo")
+`), 0o644))
+
+	got, err := DetectEmbeddedMCP(root, Options{MaxMatchesPerLanguage: 1})
+	require.NoError(t, err)
+
+	languages := map[string]bool{}
+	for _, match := range got.Detection.Matches {
+		languages[match.Language] = true
+	}
+	assert.True(t, languages["go"], "expected Go match")
+	assert.True(t, languages["python"], "expected Python match")
 }

--- a/pkg/sourcedetect/patterns.go
+++ b/pkg/sourcedetect/patterns.go
@@ -16,9 +16,11 @@ var signatures = []SDKSignature{
 		FileExtensions: []string{".go"},
 		ImportPatterns: []*regexp.Regexp{
 			regexp.MustCompile(`"github\.com/modelcontextprotocol/go-sdk(?:/mcp)?"`),
+			regexp.MustCompile(`"github\.com/mark3labs/mcp-go/server"`),
 		},
 		InitPatterns: []*regexp.Regexp{
 			regexp.MustCompile(`\bmcp\.NewServer\s*\(`),
+			regexp.MustCompile(`\bserver\.NewMCPServer\s*\(`),
 		},
 		ToolDefPatterns: []*regexp.Regexp{
 			regexp.MustCompile(`\b(?:server\.)?AddTool\s*\(`),
@@ -40,7 +42,7 @@ var signatures = []SDKSignature{
 	},
 	{
 		Language:       "typescript",
-		FileExtensions: []string{".ts", ".tsx", ".js", ".mjs"},
+		FileExtensions: []string{".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"},
 		ImportPatterns: []*regexp.Regexp{
 			regexp.MustCompile(`["']@modelcontextprotocol/sdk`),
 		},


### PR DESCRIPTION
## What changed
- fail closed on `scan --server`, `gate`, `tooltrust_scan_server`, and `tooltrust_scan_config` unless an unsafe live scan opt-in is set
- preserve nested MCP metadata and schema, and walk nested properties in the analyzers
- stop live scan dependency enrichment from using the caller cwd as an unrelated project root
- build the GitHub Action from the checked-out ref and pin the npm wrapper to the package release tag
- use per-dependency lookup timeouts and add Yarn Berry lockfile parsing
- normalize home-directory resolution for config and model paths
- fix live local dependency parsing for PNPM peer-suffixed keys and `requirements.txt` inline comments / environment markers
- strip Python requirement extras from exact pins before dependency lookup
- parse Python `===` exact pins without corrupting the version
- strip pip hash options and line-continuation backslashes from exact-pinned requirement versions
- parse CVSS v3 vector strings from OSV so Critical vulnerabilities are not downgraded to High
- validate `repo_url` hosts before remote lockfile fetches and normalize trailing `.git/` GitHub URLs
- tolerate boolean npm `bundleDependencies` / `bundledDependencies` registry fields so package scripts and IOC metadata are still inspected
- keep `scan-repo` source detection capped per language without hiding other languages
- expand `scan-repo` detection to cover mark3labs Go MCP servers and CommonJS / JSX MCP SDK files
- populate and render dependency visibility context in MCP scan reports using the same helper as the CLI
- preserve dependency `source` metadata from MCP `metadata.dependencies` entries
- preserve dependency source provenance in supply-chain issue evidence
- stop AS-014 from warning when an MCP tool exposes a usable `repo_url`
- parse JSON-RPC wrapped MCP `tools/list` responses instead of silently scanning zero tools
- preserve standard MCP `_meta` fields alongside legacy `metadata` fields
- merge current `main` into the PR branch so the PR is up to date

## Why
The scanner had several high-impact fidelity and safety bugs at once: live scans executed the target command on the host before ToolTrust could score it, MCP adapters dropped nested schema and metadata, live dependency enrichment could import unrelated lockfiles from the caller repo, packaging paths fetched mutable `latest` binaries, local lockfile parsing missed common dependency formats, Python requirement pins with extras, `===`, hashes, or continuation backslashes produced package/version strings OSV would not match, OSV vector severities could be under-classified, remote lockfile fetches trusted malformed GitHub-looking URLs, npm registry decoding could drop package evidence on common field shapes, source-repo detection could miss embedded MCP servers depending on language ordering or SDK style, MCP report generation dropped dependency visibility fields that the CLI already surfaced, MCP dependency parsing discarded per-dependency provenance needed to label verified lockfile evidence correctly, supply-chain issue generation overwrote dependency provenance back to plain `metadata`, the dependency-inventory checker used dependency collection instead of checking visibility fields directly, valid JSON-RPC `tools/list` payloads were treated as empty, and standard MCP `_meta` fields were ignored.

## Impact
- live scanning is explicit and fail-closed by default across the CLI and MCP tool surfaces
- MCP live-scan tools now require `allow_unsafe_live_scan=true` before launching target commands or configured servers
- AS-005, AS-010, AS-011, context inference, and input-surface checks now see nested schema and metadata
- local lockfiles no longer pollute unrelated live scans
- PNPM peer dependency suffixes and Python requirement markers/comments no longer break local dependency evidence
- Python requirement extras, triple-equals exact pins, hashes, and continuation backslashes now map to package/version values OSV can query
- CVSS v3 vector severities are scored instead of falling back to High
- remote lockfile enrichment no longer fetches attacker-controlled non-GitHub hosts that merely contain `github.com/` in the path
- npm lifecycle-script and IOC checks keep working when registry metadata uses boolean bundle dependency fields
- Action and npm installs are version-pinned instead of following `latest`
- dependency lookups no longer silently stop after one slow package
- Windows config lookup honors HOME-style test sandboxes
- `scan-repo` reports matches across multiple languages and recognizes more common embedded MCP server implementations
- MCP scan output no longer loses dependency inventory visibility and explanatory notes
- MCP adapter output keeps dependency provenance such as `local_lockfile`, so visibility labels stay accurate
- AS-004/AS-008/AS-015/AS-016 evidence can now distinguish declared metadata from verified lockfile-derived dependency entries
- AS-014 no longer emits a misleading “no metadata.dependencies or repo_url” warning when `repo_url` is present
- pasted JSON-RPC `tools/list` responses and live mcp-go `_meta` metadata now retain tool definitions and analyzer inputs

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- targeted repros for unsafe live scan opt-in in CLI and MCP tools, nested metadata/schema findings, cwd lockfile pollution, Yarn Berry parsing, HOME fallback behavior, PNPM peer key parsing, requirements marker/comment parsing, Python requirement extras, Python `===` pins, pip hash/continuation requirements, CVSS vector severity, GitHub repo URL host validation, trailing `.git/` repo URL normalization, boolean npm bundle dependency fields, scan-repo per-language caps, mark3labs Go detection, CommonJS MCP SDK detection, MCP dependency visibility propagation, MCP dependency visibility text rendering, MCP dependency source preservation, supply-chain evidence source preservation, AS-014 repo URL false-positive prevention, JSON-RPC `tools/list` parsing, and MCP `_meta` preservation