### PR TITLE
sourcedetect: detect unauthenticated MCP route exposure

### DIFF
--- a/cmd/tooltrust-scanner/main.go
+++ b/cmd/tooltrust-scanner/main.go
@@ -764,6 +764,7 @@ var ruleHint = map[string]string{
 	"AS-016": "→ Treat this package version as a likely compromise. Remove it, rotate exposed credentials, and inspect the dependency tree for the IOC package before reinstalling.",
 	"AS-017": "→ Review whether the tool description is instructing external data forwarding. If intentional, require approval and narrow the destination scope.",
 	"AS-018": "→ Run a sandboxed live scan when possible, or add a tools manifest so the embedded MCP implementation can be reviewed without executing the server.",
+	"AS-019": "→ Apply equivalent authentication middleware to every MCP HTTP route, and avoid fail-open allowlist defaults on alternate endpoints such as /mcp_message.",
 }
 
 // formatIssueLabel returns a coloured finding line with optional evidence and fix hint.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,6 +1,6 @@
 # Security Rules
 
-ToolTrust Scanner checks every MCP tool against 16 active built-in rules.
+ToolTrust Scanner checks every MCP tool against 17 active built-in rules.
 Each rule fires independently; a tool can trigger multiple rules.
 
 ---
@@ -138,3 +138,27 @@ Flags npm dependency versions whose published registry metadata or install-time 
 **Severity:** Medium
 
 Flags tool descriptions that explicitly suggest forwarding user data, content, or conversation history to external endpoints such as remote hosts, external servers, attacker-controlled URLs, or base64-encoded sinks. This is intentionally separate from AS-001 so prompt-injection findings stay focused on instruction override language.
+
+---
+
+## ℹ️ AS-018 — Embedded MCP Server Detected
+
+**Severity:** Info
+
+Flags repositories where MCP SDK imports and server initialization are present in source code, but the scanner could not enumerate tool definitions from a manifest or live handshake.
+
+This is a presence signal, not a clean bill of health. It tells you the repo likely exposes MCP functionality, but more review is needed to understand tools, auth, and scope.
+
+---
+
+## 🚨 AS-019 — Unauthenticated MCP Route Exposure
+
+**Severity:** High / Critical
+
+Flags embedded MCP HTTP servers where one route reaches the MCP handler without the authentication middleware applied on another route serving the same handler.
+
+The initial implementation focuses on Go/Gin-style route registrations and raises severity when it sees strong exploitability signals such as:
+
+- an unauthenticated alternate MCP route like `/mcp_message`
+- fail-open IP allowlist logic
+- the same handler used by both authenticated and unauthenticated MCP endpoints

--- a/pkg/sourcedetect/detector.go
+++ b/pkg/sourcedetect/detector.go
@@ -106,6 +106,17 @@ func DetectEmbeddedMCP(root string, opts Options) (*DetectionResult, error) {
 		}}
 	}
 
+	routeFindings, routeIssues, routeErr := detectRouteAuthAsymmetry(root, opts)
+	if routeErr != nil {
+		return nil, routeErr
+	}
+	if len(routeFindings) > 0 {
+		result.Detection.RouteFindings = routeFindings
+	}
+	if len(routeIssues) > 0 {
+		result.Findings = append(result.Findings, routeIssues...)
+	}
+
 	return result, nil
 }
 

--- a/pkg/sourcedetect/detector_test.go
+++ b/pkg/sourcedetect/detector_test.go
@@ -56,3 +56,33 @@ func TestDetectEmbeddedMCP_SkipAndIgnoreRules(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectEmbeddedMCP_AS019RouteAuthAsymmetry(t *testing.T) {
+	got, err := DetectEmbeddedMCP(filepath.Join("testdata", "fixtures", "go-gin-auth-asymmetry"), Options{})
+	require.NoError(t, err)
+	require.True(t, got.HasEmbeddedMCP)
+	require.Len(t, got.Detection.RouteFindings, 1)
+	assert.Equal(t, "/mcp", got.Detection.RouteFindings[0].Authenticated.Path)
+	assert.Equal(t, "/mcp_message", got.Detection.RouteFindings[0].Unauthenticated.Path)
+	require.NotNil(t, got.Detection.RouteFindings[0].FailOpenEvidence)
+
+	var found bool
+	for _, issue := range got.Findings {
+		if issue.RuleID == "AS-019" {
+			found = true
+			assert.Equal(t, "CRITICAL", string(issue.Severity))
+			assert.Contains(t, issue.Description, "/mcp_message")
+		}
+	}
+	assert.True(t, found, "expected AS-019 finding")
+}
+
+func TestDetectEmbeddedMCP_AS019NoFalsePositiveWhenAuthConsistent(t *testing.T) {
+	got, err := DetectEmbeddedMCP(filepath.Join("testdata", "fixtures", "go-gin-auth-consistent"), Options{})
+	require.NoError(t, err)
+	require.True(t, got.HasEmbeddedMCP)
+	assert.Empty(t, got.Detection.RouteFindings)
+	for _, issue := range got.Findings {
+		assert.NotEqual(t, "AS-019", issue.RuleID)
+	}
+}

--- a/pkg/sourcedetect/result.go
+++ b/pkg/sourcedetect/result.go
@@ -17,9 +17,10 @@ type DetectionResult struct {
 }
 
 type DetectionSummary struct {
-	Matches      []Match `json:"matches,omitempty"`
-	FilesScanned int     `json:"files_scanned"`
-	Elapsed      string  `json:"elapsed"`
+	Matches       []Match        `json:"matches,omitempty"`
+	RouteFindings []RouteFinding `json:"route_findings,omitempty"`
+	FilesScanned  int            `json:"files_scanned"`
+	Elapsed       string         `json:"elapsed"`
 }
 
 type Match struct {
@@ -32,6 +33,20 @@ type Evidence struct {
 	Kind    string `json:"kind"`
 	Line    int    `json:"line"`
 	Snippet string `json:"snippet"`
+}
+
+type RouteFinding struct {
+	Language         string     `json:"language"`
+	File             string     `json:"file"`
+	Authenticated    RouteMatch `json:"authenticated"`
+	Unauthenticated  RouteMatch `json:"unauthenticated"`
+	FailOpenEvidence *Evidence  `json:"fail_open_evidence,omitempty"`
+}
+
+type RouteMatch struct {
+	Path    string `json:"path"`
+	Line    int    `json:"line"`
+	Handler string `json:"handler"`
 }
 
 func defaultOptions() Options {

--- a/pkg/sourcedetect/routes.go
+++ b/pkg/sourcedetect/routes.go
@@ -1,0 +1,260 @@
+package sourcedetect
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/AgentSafe-AI/tooltrust-scanner/pkg/model"
+)
+
+type routeRegistration struct {
+	File        string
+	Line        int
+	Path        string
+	Handler     string
+	HasAuth     bool
+	HasIPFilter bool
+	Block       string
+}
+
+var (
+	routeStartPattern  = regexp.MustCompile(`\.\s*(?:Any|GET|POST|PUT|PATCH|DELETE|Handle)\s*\(`)
+	quotedPathPattern  = regexp.MustCompile(`"(/[^"]+)"`)
+	handlerCallPattern = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_.]*)\s*\(\s*c\s*\)`)
+)
+
+func detectRouteAuthAsymmetry(root string, opts Options) ([]RouteFinding, []model.Issue, error) {
+	var routes []routeRegistration
+	failOpenEvidence := map[string]Evidence{}
+
+	filesScanned, err := walkSourceFiles(root, opts, func(rel, abs string, _ fs.DirEntry) error {
+		if strings.ToLower(filepath.Ext(rel)) != ".go" {
+			return nil
+		}
+		// #nosec G304 -- abs is produced by walkSourceFiles under the requested repo root.
+		content, readErr := os.ReadFile(abs)
+		if readErr != nil {
+			return nil
+		}
+		text := string(content)
+		routes = append(routes, extractRouteRegistrations(rel, text)...)
+		if ev, ok := findFailOpenWhitelistEvidence(text); ok {
+			failOpenEvidence[rel] = ev
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	_ = filesScanned
+
+	findings, issues := correlateRouteRegistrations(routes, failOpenEvidence)
+	return findings, issues, nil
+}
+
+func extractRouteRegistrations(rel, text string) []routeRegistration {
+	var out []routeRegistration
+	lines := strings.Split(text, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		loc := routeStartPattern.FindStringIndex(line)
+		if loc == nil {
+			continue
+		}
+
+		startLine := i + 1
+		block, endLine := captureCallBlock(lines, i)
+		if block == "" {
+			continue
+		}
+		i = endLine
+
+		pathMatch := quotedPathPattern.FindStringSubmatch(block)
+		if len(pathMatch) < 2 {
+			continue
+		}
+		handler := extractHandlerCall(block)
+		if handler == "" || !strings.Contains(strings.ToLower(pathMatch[1]), "mcp") {
+			continue
+		}
+
+		out = append(out, routeRegistration{
+			File:        rel,
+			Line:        startLine,
+			Path:        pathMatch[1],
+			Handler:     handler,
+			HasAuth:     strings.Contains(block, "AuthRequired("),
+			HasIPFilter: strings.Contains(block, "IPWhiteList("),
+			Block:       block,
+		})
+	}
+	return out
+}
+
+func captureCallBlock(lines []string, start int) (block string, endLine int) {
+	var b strings.Builder
+	depth := 0
+	started := false
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(line)
+		for _, ch := range line {
+			switch ch {
+			case '(':
+				depth++
+				started = true
+			case ')':
+				if depth > 0 {
+					depth--
+				}
+			}
+		}
+		if started && depth == 0 {
+			return b.String(), i
+		}
+	}
+	return "", start
+}
+
+func extractHandlerCall(block string) string {
+	matches := handlerCallPattern.FindAllStringSubmatch(block, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		handler := match[1]
+		if strings.Contains(handler, "AuthRequired") || strings.Contains(handler, "IPWhiteList") {
+			continue
+		}
+		return handler
+	}
+	return ""
+}
+
+func findFailOpenWhitelistEvidence(text string) (Evidence, bool) {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "IPWhiteList") && !strings.Contains(line, "IPWhitelist") {
+			continue
+		}
+		window := strings.Join(lines[i:intMin(i+12, len(lines))], "\n")
+		if strings.Contains(window, "len(") && strings.Contains(window, "== 0") && strings.Contains(window, "c.Next()") {
+			return Evidence{
+				Kind:    "fail_open_whitelist",
+				Line:    i + 1,
+				Snippet: strings.TrimSpace(line),
+			}, true
+		}
+	}
+	return Evidence{}, false
+}
+
+func correlateRouteRegistrations(routes []routeRegistration, failOpen map[string]Evidence) ([]RouteFinding, []model.Issue) {
+	type pairKey struct {
+		file    string
+		handler string
+	}
+	byKey := map[pairKey][]routeRegistration{}
+	for _, route := range routes {
+		byKey[pairKey{file: route.File, handler: route.Handler}] = append(byKey[pairKey{file: route.File, handler: route.Handler}], route)
+	}
+
+	var findings []RouteFinding
+	var issues []model.Issue
+	seen := map[string]bool{}
+
+	for key, regs := range byKey {
+		var authRoute *routeRegistration
+		var unauthRoute *routeRegistration
+		for i := range regs {
+			reg := regs[i]
+			if reg.HasAuth && authRoute == nil {
+				authRoute = &reg
+			}
+			if !reg.HasAuth && unauthRoute == nil {
+				unauthRoute = &reg
+			}
+		}
+		if authRoute == nil || unauthRoute == nil {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(unauthRoute.Path), "mcp") {
+			continue
+		}
+
+		findKey := fmt.Sprintf("%s|%s|%s|%s", key.file, key.handler, authRoute.Path, unauthRoute.Path)
+		if seen[findKey] {
+			continue
+		}
+		seen[findKey] = true
+
+		rf := RouteFinding{
+			Language: "go",
+			File:     key.file,
+			Authenticated: RouteMatch{
+				Path:    authRoute.Path,
+				Line:    authRoute.Line,
+				Handler: authRoute.Handler,
+			},
+			Unauthenticated: RouteMatch{
+				Path:    unauthRoute.Path,
+				Line:    unauthRoute.Line,
+				Handler: unauthRoute.Handler,
+			},
+		}
+		if ev, ok := failOpen[key.file]; ok {
+			evCopy := ev
+			rf.FailOpenEvidence = &evCopy
+		} else if unauthRoute.HasIPFilter || authRoute.HasIPFilter {
+			for _, ev := range failOpen {
+				evCopy := ev
+				rf.FailOpenEvidence = &evCopy
+				break
+			}
+		}
+		findings = append(findings, rf)
+
+		severity := model.SeverityHigh
+		desc := fmt.Sprintf("MCP route %s reaches %s without the authentication middleware applied on %s.", unauthRoute.Path, unauthRoute.Handler, authRoute.Path)
+		if rf.FailOpenEvidence != nil || strings.EqualFold(unauthRoute.Path, "/mcp_message") {
+			severity = model.SeverityCritical
+			desc = fmt.Sprintf("MCP route %s appears reachable without authentication while %s protects the same handler %s. This may allow unauthenticated remote MCP tool invocation.", unauthRoute.Path, authRoute.Path, unauthRoute.Handler)
+		}
+
+		evidence := []model.Evidence{
+			{Kind: "authenticated_route", Value: fmt.Sprintf("%s:%d", authRoute.File, authRoute.Line)},
+			{Kind: "unauthenticated_route", Value: fmt.Sprintf("%s:%d", unauthRoute.File, unauthRoute.Line)},
+		}
+		if rf.FailOpenEvidence != nil {
+			evidence = append(evidence, model.Evidence{
+				Kind:  "fail_open_whitelist",
+				Value: fmt.Sprintf("%s:%d", key.file, rf.FailOpenEvidence.Line),
+			})
+		}
+
+		issues = append(issues, model.Issue{
+			RuleID:      "AS-019",
+			Severity:    severity,
+			Code:        "MCP_AUTH_ASYMMETRY",
+			Description: desc,
+			Location:    key.file,
+			Evidence:    evidence,
+		})
+	}
+
+	return findings, issues
+}
+
+func intMin(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/sourcedetect/testdata/fixtures/go-gin-auth-asymmetry/router.go
+++ b/pkg/sourcedetect/testdata/fixtures/go-gin-auth-asymmetry/router.go
@@ -1,0 +1,22 @@
+package router
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var srv = server.NewMCPServer("demo", "1.0.0")
+
+func init() {
+	srv.AddTool(mcp.Tool{}, nil)
+}
+
+func Register(api Router, mcpHandler *server.StreamableHTTPServer) {
+	api.Any("/mcp", AuthRequired(), IPWhiteList(), func(c *Context) {
+		mcpHandler.ServeHTTP(c)
+	})
+
+	api.Any("/mcp_message", IPWhiteList(), func(c *Context) {
+		mcpHandler.ServeHTTP(c)
+	})
+}

--- a/pkg/sourcedetect/testdata/fixtures/go-gin-auth-asymmetry/whitelist.go
+++ b/pkg/sourcedetect/testdata/fixtures/go-gin-auth-asymmetry/whitelist.go
@@ -1,0 +1,10 @@
+package router
+
+func IPWhiteList() HandlerFunc {
+	return func(c *Context) {
+		if len(whitelist) == 0 {
+			c.Next()
+			return
+		}
+	}
+}

--- a/pkg/sourcedetect/testdata/fixtures/go-gin-auth-consistent/router.go
+++ b/pkg/sourcedetect/testdata/fixtures/go-gin-auth-consistent/router.go
@@ -1,0 +1,22 @@
+package router
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var srv = server.NewMCPServer("demo", "1.0.0")
+
+func init() {
+	srv.AddTool(mcp.Tool{}, nil)
+}
+
+func Register(api Router, mcpHandler *server.StreamableHTTPServer) {
+	api.Any("/mcp", AuthRequired(), func(c *Context) {
+		mcpHandler.ServeHTTP(c)
+	})
+
+	api.Any("/mcp_message", AuthRequired(), func(c *Context) {
+		mcpHandler.ServeHTTP(c)
+	})
+}


### PR DESCRIPTION
## Summary
- add AS-019 sourcedetect rule for unauthenticated MCP route exposure in embedded Go/Gin servers
- detect auth asymmetry when one MCP route protects a handler and another route exposes the same handler without equivalent auth
- add fixtures and tests covering the nginx-ui style /mcp vs /mcp_message pattern

## Testing
- go test ./...
