### PR TITLE
feat: add Mini Shai-Hulud supply-chain IOCs

### DIFF
--- a/.github/workflows/ioc-candidates.yml
+++ b/.github/workflows/ioc-candidates.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   generate-candidates:
-    name: Generate OSV blacklist candidates
+    name: Generate OSV compromise candidates
     runs-on: ubuntu-latest
 
     steps:
@@ -69,17 +69,18 @@ jobs:
         with:
           token: ${{ secrets.TOOLTRUST_BOT_TOKEN || github.token }}
           branch: ioc-candidates/${{ github.run_id }}
-          title: "ioc: ${{ steps.candidate_count.outputs.count }} new blacklist candidate(s)"
-          commit-message: "data(blacklist): auto-append ${{ steps.candidate_count.outputs.count }} OSV candidate(s)"
+          title: "ioc: ${{ steps.candidate_count.outputs.count }} new compromise candidate(s)"
+          commit-message: "data(blacklist): auto-append ${{ steps.candidate_count.outputs.count }} OSV compromise candidate(s)"
           body: |
-            Automated IOC blacklist candidates generated from OSV ecosystem feeds for the last 24 hours.
+            Automated IOC compromise candidates generated from OSV ecosystem feeds for the last 24 hours.
 
             Review each entry carefully:
+            - Does this read like a real supply-chain compromise or malicious publish, rather than an ordinary CVE?
             - Is the version pinning exact and narrow enough?
             - Is `BLOCK` the right action, or should this be downgraded to `WARN`?
             - Is the reason clear enough for someone triaging a finding?
 
-            Close this PR if any candidate looks incorrect. The workflow will retry on the next scheduled run.
+            Close this PR if any candidate looks like a normal vulnerability that should stay in AS-004 / OSV instead of the manual blacklist.
           labels: |
             ioc
             automated

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -71,7 +71,7 @@ Tools with no description or no input schema give the agent no basis for safe us
 
 Checks an offline bundled blacklist of packages confirmed to have been compromised in supply chain attacks. No network required — zero latency.
 
-Current blacklist: LiteLLM 1.82.7/1.82.8 (TeamPCP `.pth` backdoor), Trivy v0.69.4–v0.69.6 (CI pipeline compromise), Langflow < 1.9.0 (unauthenticated RCE), Axios 1.14.1/0.30.4 (malicious npm publish).
+Current blacklist: LiteLLM 1.82.7/1.82.8 (TeamPCP `.pth` backdoor), Trivy v0.69.4–v0.69.6 (CI pipeline compromise), Langflow < 1.9.0 (unauthenticated RCE), Axios 1.14.1/0.30.4 (malicious npm publish), Bitwarden CLI 2026.4.0, and Mini Shai-Hulud/TanStack-related compromised npm/PyPI package versions.
 
 ---
 
@@ -129,7 +129,7 @@ Flags npm dependency versions that publish install-time lifecycle scripts such a
 
 **Severity:** Critical
 
-Flags npm dependency versions whose published registry metadata or install-time scripts reference known malicious IOC package names, domains, URLs, or script patterns, such as `plain-crypto-js` or reviewed shell-fetch indicators. This is narrower than full tarball signature scanning, but it can still catch compromised releases when an IOC appears in dependency metadata.
+Flags npm dependency versions whose published registry metadata or install-time scripts reference known malicious IOC package names, domains, URLs, or script patterns, such as `plain-crypto-js`, `@tanstack/setup`, Mini Shai-Hulud infrastructure, or reviewed shell-fetch indicators. This is narrower than full tarball signature scanning, but it can still catch compromised releases when an IOC appears in dependency metadata.
 
 ---
 

--- a/docs/ioc-pipeline.md
+++ b/docs/ioc-pipeline.md
@@ -1,12 +1,13 @@
 # IOC Blacklist Auto-Candidate Pipeline
 
-This workflow adds a daily review loop for likely blacklist entries without silently editing the live scanner data.
+This workflow adds a daily review loop for likely compromise-oriented blacklist entries without silently editing the live scanner data.
 
 ## What it does
 
 - pulls recent OSV ecosystem advisories for `npm`, `PyPI`, and `Go`
 - filters to advisories published in the last 24 hours
 - keeps only `HIGH` and `CRITICAL` candidates
+- keeps only advisories whose summary/details read like a supply-chain compromise, malicious publish, or similarly high-confidence blacklist event
 - skips package versions already present in [`pkg/analyzer/data/blacklist.json`](/Users/brian93512/projects/tooltrust-scanner/pkg/analyzer/data/blacklist.json)
 - opens one review PR with candidate blacklist entries
 
@@ -14,16 +15,17 @@ The workflow never auto-merges. A human still decides whether a candidate belong
 
 ## Why this exists
 
-Our blacklist is strong once an entry exists, but hand-editing it means we can lag major supply-chain events by hours. This pipeline narrows that gap by surfacing review-ready candidates quickly after OSV publishes an advisory.
+Our blacklist is strong once an entry exists, but hand-editing it means we can lag major supply-chain events by hours. This pipeline narrows that gap by surfacing review-ready compromise candidates quickly after OSV publishes an advisory, without turning every ordinary CVE into a hard block.
 
 ## Review checklist
 
 When the workflow opens a PR:
 
 1. confirm the affected versions are exact and narrow enough
-2. confirm `BLOCK` is the correct action
-3. rewrite the reason if the current summary is too vague for triage
-4. close the PR if the advisory is too broad, too noisy, or otherwise not suitable for blacklist enforcement
+2. confirm the advisory really belongs in the compromise blacklist rather than ordinary OSV/CVE triage
+3. confirm `BLOCK` is the correct action
+4. rewrite the reason if the current summary is too vague for triage
+5. close the PR if the advisory is too broad, too noisy, or otherwise not suitable for blacklist enforcement
 
 ## Local dry run
 

--- a/pkg/analyzer/blacklist_test.go
+++ b/pkg/analyzer/blacklist_test.go
@@ -112,6 +112,45 @@ func TestBlacklist_Axios_SafeVersion_NoFinding(t *testing.T) {
 	assert.Empty(t, issues)
 }
 
+func TestBlacklist_TanStackMiniShaiHulud_Hit(t *testing.T) {
+	bc := analyzer.NewBlacklistChecker()
+	tool := toolWithDep("@tanstack/react-router", "1.169.8", "npm")
+	issues, err := bc.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "SUPPLY_CHAIN_BLOCK", issues[0].Code)
+	assert.Equal(t, model.SeverityCritical, issues[0].Severity)
+	assert.Contains(t, issues[0].Description, "CVE-2026-45321")
+	assert.Contains(t, issues[0].Description, "Mini Shai-Hulud")
+	assert.Contains(t, issues[0].Description, "@tanstack/react-router@1.169.8")
+}
+
+func TestBlacklist_TanStackPatchedVersion_NoFinding(t *testing.T) {
+	bc := analyzer.NewBlacklistChecker()
+	tool := toolWithDep("@tanstack/react-router", "1.169.9", "npm")
+	issues, err := bc.Check(tool)
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
+func TestBlacklist_MiniShaiHuludPyPI_Hit(t *testing.T) {
+	bc := analyzer.NewBlacklistChecker()
+	for _, tc := range []struct {
+		name    string
+		version string
+	}{
+		{name: "mistralai", version: "2.4.6"},
+		{name: "guardrails-ai", version: "0.10.1"},
+	} {
+		tool := toolWithDep(tc.name, tc.version, "PyPI")
+		issues, err := bc.Check(tool)
+		require.NoError(t, err, "%s", tc.name)
+		require.Len(t, issues, 1, "%s should be blocked", tc.name)
+		assert.Equal(t, "SUPPLY_CHAIN_BLOCK", issues[0].Code)
+		assert.Contains(t, issues[0].Description, "MINI-SHAI-HULUD-2026-05-11")
+	}
+}
+
 func TestBlacklist_RepoURLLockfileDependency_Hit(t *testing.T) {
 	withLockfileDepsForTest(t, []analyzer.Dependency{
 		{Name: "axios", Version: "1.14.1", Ecosystem: "npm"},

--- a/pkg/analyzer/data/blacklist.json
+++ b/pkg/analyzer/data/blacklist.json
@@ -68,5 +68,455 @@
     "severity": "CRITICAL",
     "reason": "Confirmed npm supply-chain compromise: attackers hijacked Bitwarden's GitHub Actions, stole release secrets, and pushed a tampered @bitwarden/cli@2026.4.0 build to npm containing malicious code. Remove immediately and rotate any credentials that passed through the CLI.",
     "link": "https://thehackernews.com/2026/04/bitwarden-cli-supply-chain-attack.html"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/arktype-adapter",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.12", "1.166.15"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/eslint-plugin-router",
+    "ecosystem": "npm",
+    "affected_versions": ["1.161.9", "1.161.12"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/eslint-plugin-start",
+    "ecosystem": "npm",
+    "affected_versions": ["0.0.4", "0.0.7"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/history",
+    "ecosystem": "npm",
+    "affected_versions": ["1.161.9", "1.161.12"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/nitro-v2-vite-plugin",
+    "ecosystem": "npm",
+    "affected_versions": ["1.154.12", "1.154.15"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-router",
+    "ecosystem": "npm",
+    "affected_versions": ["1.169.5", "1.169.8"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-router-devtools",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.16", "1.166.19"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-router-ssr-query",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.15", "1.166.18"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-start",
+    "ecosystem": "npm",
+    "affected_versions": ["1.167.68", "1.167.71"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-start-client",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.51", "1.166.54"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-start-rsc",
+    "ecosystem": "npm",
+    "affected_versions": ["0.0.47", "0.0.50"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/react-start-server",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.55", "1.166.58"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-cli",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.46", "1.166.49"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-core",
+    "ecosystem": "npm",
+    "affected_versions": ["1.169.5", "1.169.8"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-devtools",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.16", "1.166.19"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-devtools-core",
+    "ecosystem": "npm",
+    "affected_versions": ["1.167.6", "1.167.9"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-generator",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.45", "1.166.48"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-plugin",
+    "ecosystem": "npm",
+    "affected_versions": ["1.167.38", "1.167.41"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-ssr-query-core",
+    "ecosystem": "npm",
+    "affected_versions": ["1.168.3", "1.168.6"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-utils",
+    "ecosystem": "npm",
+    "affected_versions": ["1.161.11", "1.161.14"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/router-vite-plugin",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.53", "1.166.56"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/solid-router",
+    "ecosystem": "npm",
+    "affected_versions": ["1.169.5", "1.169.8"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/solid-router-devtools",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.16", "1.166.19"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/solid-router-ssr-query",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.15", "1.166.18"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/solid-start",
+    "ecosystem": "npm",
+    "affected_versions": ["1.167.65", "1.167.68"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/solid-start-client",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.50", "1.166.53"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/solid-start-server",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.54", "1.166.57"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/start-client-core",
+    "ecosystem": "npm",
+    "affected_versions": ["1.168.5", "1.168.8"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/start-fn-stubs",
+    "ecosystem": "npm",
+    "affected_versions": ["1.161.9", "1.161.12"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/start-plugin-core",
+    "ecosystem": "npm",
+    "affected_versions": ["1.169.23", "1.169.26"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/start-server-core",
+    "ecosystem": "npm",
+    "affected_versions": ["1.167.33", "1.167.36"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/start-static-server-functions",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.44", "1.166.47"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/start-storage-context",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.38", "1.166.41"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/valibot-adapter",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.12", "1.166.15"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/virtual-file-routes",
+    "ecosystem": "npm",
+    "affected_versions": ["1.161.10", "1.161.13"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/vue-router",
+    "ecosystem": "npm",
+    "affected_versions": ["1.169.5", "1.169.8"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/vue-router-devtools",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.16", "1.166.19"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/vue-router-ssr-query",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.15", "1.166.18"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/vue-start",
+    "ecosystem": "npm",
+    "affected_versions": ["1.167.61", "1.167.64"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/vue-start-client",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.46", "1.166.49"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/vue-start-server",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.50", "1.166.53"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "CVE-2026-45321",
+    "component": "@tanstack/zod-adapter",
+    "ecosystem": "npm",
+    "affected_versions": ["1.166.12", "1.166.15"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
+    "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
+  },
+  {
+    "id": "MINI-SHAI-HULUD-2026-05-11",
+    "component": "@opensearch-project/opensearch",
+    "ecosystem": "npm",
+    "affected_versions": ["3.5.3", "3.6.2", "3.7.0", "3.8.0"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud supply-chain compromise: confirmed malicious package artifacts tied to credential theft and remote payload execution across npm/PyPI ecosystems.",
+    "link": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack"
+  },
+  {
+    "id": "MINI-SHAI-HULUD-2026-05-11",
+    "component": "mistralai",
+    "ecosystem": "PyPI",
+    "affected_versions": ["2.4.6"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud supply-chain compromise: compromised PyPI release reportedly downloads and executes a secondary payload on Linux systems and targets developer credentials.",
+    "link": "https://thehackernews.com/2026/05/tanstack-supply-chain-attack-hits-two.html"
+  },
+  {
+    "id": "MINI-SHAI-HULUD-2026-05-11",
+    "component": "guardrails-ai",
+    "ecosystem": "PyPI",
+    "affected_versions": ["0.10.1"],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud supply-chain compromise: compromised PyPI release downloads a remote Python artifact and executes it without integrity verification.",
+    "link": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack"
   }
 ]

--- a/pkg/analyzer/data/npm_iocs.json
+++ b/pkg/analyzer/data/npm_iocs.json
@@ -19,5 +19,70 @@
     "source": "https://github.com/AgentSafe-AI/tooltrust-scanner/blob/main/pkg/analyzer/npm_scripts.go",
     "first_seen": "2026-03-31",
     "suggested_action": "flag"
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "package_name",
+    "name": "@tanstack/setup",
+    "reason": "Mini Shai-Hulud / TanStack IOC: malicious package manifests added this fictitious optional dependency pointing at github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c.",
+    "confidence": "high",
+    "source": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx",
+    "first_seen": "2026-05-11",
+    "suggested_action": "flag"
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "domain",
+    "value": "filev2.getsession.org",
+    "match": "exact",
+    "reason": "Mini Shai-Hulud / TanStack IOC: exfiltration network used by the credential-stealing payload.",
+    "confidence": "high",
+    "source": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx",
+    "first_seen": "2026-05-11",
+    "suggested_action": "flag"
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "domain",
+    "value": "git-tanstack.com",
+    "match": "exact",
+    "reason": "Mini Shai-Hulud IOC: attacker-controlled infrastructure used to host second-stage payloads in related npm/PyPI compromises.",
+    "confidence": "high",
+    "source": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack",
+    "first_seen": "2026-05-12",
+    "suggested_action": "flag"
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "url",
+    "value": "https://litter.catbox.moe/h8nc9u.js",
+    "match": "exact",
+    "reason": "Mini Shai-Hulud / TanStack IOC: reported second-stage payload URL.",
+    "confidence": "high",
+    "source": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx",
+    "first_seen": "2026-05-11",
+    "suggested_action": "flag"
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "url",
+    "value": "https://litter.catbox.moe/7rrc6l.mjs",
+    "match": "exact",
+    "reason": "Mini Shai-Hulud / TanStack IOC: reported second-stage payload URL.",
+    "confidence": "high",
+    "source": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx",
+    "first_seen": "2026-05-11",
+    "suggested_action": "flag"
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "script_pattern",
+    "value": "tanstack_runner.js",
+    "match": "contains",
+    "reason": "Mini Shai-Hulud / TanStack IOC: helper payload filename in the malicious orphan git dependency.",
+    "confidence": "high",
+    "source": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx",
+    "first_seen": "2026-05-11",
+    "suggested_action": "flag"
   }
 ]

--- a/pkg/analyzer/npm_ioc_test.go
+++ b/pkg/analyzer/npm_ioc_test.go
@@ -90,6 +90,33 @@ func TestNPMIOCChecker_SuspiciousScriptPattern_Finding(t *testing.T) {
 	assert.Contains(t, issues[0].Description, "curl -fssl")
 }
 
+func TestNPMIOCChecker_TanStackSetupOptionalDependency_Finding(t *testing.T) {
+	checker := analyzer.NewNPMIOCCheckerWithMock(map[string]analyzer.NPMVersionResponseForTest{
+		"@tanstack/react-router@1.169.8": {
+			Name:                 "@tanstack/react-router",
+			Version:              "1.169.8",
+			OptionalDependencies: map[string]string{"@tanstack/setup": "github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c"},
+		},
+	}, nil)
+
+	tool := model.UnifiedTool{
+		Name: "router_mcp",
+		Metadata: map[string]any{
+			"dependencies": []any{
+				map[string]any{"name": "@tanstack/react-router", "version": "1.169.8", "ecosystem": "npm"},
+			},
+		},
+	}
+
+	issues, err := checker.Check(tool)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "AS-016", issues[0].RuleID)
+	assert.Equal(t, "NPM_IOC_DEPENDENCY", issues[0].Code)
+	assert.Equal(t, model.SeverityCritical, issues[0].Severity)
+	assert.Contains(t, issues[0].Description, "@tanstack/setup")
+}
+
 func TestNPMIOCChecker_SuspiciousDomainIOC_Finding(t *testing.T) {
 	checker := analyzer.NewNPMIOCCheckerWithMock(map[string]analyzer.NPMVersionResponseForTest{
 		"axios@1.14.1": {

--- a/scripts/ioc-candidates/fetch.go
+++ b/scripts/ioc-candidates/fetch.go
@@ -284,6 +284,9 @@ func buildCandidates(vulns []osvVulnerability, ecosystem string, existing map[st
 		if !ok || severityRank(severity) < severityRank(minSeverity) {
 			continue
 		}
+		if !looksLikeBlacklistCandidate(*vuln) {
+			continue
+		}
 
 		for _, affected := range vuln.Affected {
 			if !strings.EqualFold(strings.TrimSpace(affected.Package.Ecosystem), ecosystem) {
@@ -329,6 +332,45 @@ func buildCandidates(vulns []osvVulnerability, ecosystem string, existing map[st
 		}
 	}
 	return out
+}
+
+func looksLikeBlacklistCandidate(vuln osvVulnerability) bool {
+	text := strings.ToLower(strings.Join([]string{
+		strings.TrimSpace(vuln.Summary),
+		strings.TrimSpace(vuln.Details),
+		strings.Join(vuln.Aliases, " "),
+	}, " "))
+	if text == "" {
+		return false
+	}
+
+	signals := []string{
+		"compromised",
+		"malicious",
+		"supply chain",
+		"supply-chain",
+		"credential exfiltration",
+		"exfiltration routine",
+		"maintainer",
+		"account takeover",
+		"hijack",
+		"hijacked",
+		"backdoor",
+		"protestware",
+		"dependency confusion",
+		"typosquat",
+		"typosquatting",
+		"poisoned package",
+		"poisoned release",
+		"stolen release token",
+		"malicious dependency",
+	}
+	for _, signal := range signals {
+		if strings.Contains(text, signal) {
+			return true
+		}
+	}
+	return false
 }
 
 func readExistingBlacklist(path string) (map[string]struct{}, error) {

--- a/scripts/ioc-candidates/fetch_test.go
+++ b/scripts/ioc-candidates/fetch_test.go
@@ -64,6 +64,32 @@ func TestFetchCandidatesWithClient_FeedFailureIsWarning(t *testing.T) {
 	}
 }
 
+func TestBuildCandidates_SkipsOrdinaryHighSeverityCVEs(t *testing.T) {
+	now := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	vulns := []osvVulnerability{
+		{
+			ID:        "GHSA-generic-2026-0001",
+			Summary:   "Generic high severity SSRF vulnerability in admin endpoint.",
+			Published: "2026-04-21T18:00:00Z",
+			Severity:  []osvSeverity{{Type: "CVSS_V3", Score: "8.8"}},
+			Affected: []osvAffected{
+				{
+					Package: struct {
+						Name      string `json:"name"`
+						Ecosystem string `json:"ecosystem"`
+					}{Name: "genericpkg", Ecosystem: "npm"},
+					Versions: []string{"1.2.3"},
+				},
+			},
+		},
+	}
+
+	got := buildCandidates(vulns, "npm", map[string]struct{}{}, now, 24*time.Hour, "HIGH")
+	if len(got) != 0 {
+		t.Fatalf("expected ordinary CVE to be skipped, got %#v", got)
+	}
+}
+
 type httpClientStub struct{}
 
 func (h *httpClientStub) Do(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary
- add offline AS-008 blocklist coverage for CVE-2026-45321 across 42 TanStack npm packages
- add confirmed Mini Shai-Hulud entries for OpenSearch npm, mistralai PyPI, and guardrails-ai PyPI
- add AS-016 npm IOC coverage for @tanstack/setup and related Mini Shai-Hulud infrastructure

## Verification
- go test ./pkg/analyzer
- go test ./...