### PR TITLE
ci: make IOC candidates review-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ["1.26"]
+        go: ["1.26.4"]
 
     steps:
       - name: Download source tree
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Run golangci-lint
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build CLI (tooltrust-scanner)
@@ -180,7 +180,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build tooltrust-scanner binary
@@ -230,7 +230,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Verify go install (README primary method)

--- a/.github/workflows/ioc-candidates.yml
+++ b/.github/workflows/ioc-candidates.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   generate-candidates:
-    name: Generate OSV compromise candidates
+    name: Generate OSV review candidates
     runs-on: ubuntu-latest
 
     steps:
@@ -53,15 +53,11 @@ jobs:
           count="$(jq 'length' /tmp/candidates.json)"
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
-      - name: Merge candidates into blacklist
+      - name: Prepare review artifact
         if: steps.candidate_count.outputs.count != '0'
         run: |
-          jq -s '
-            (.[0] + .[1])
-            | unique_by("\(.ecosystem)|\(.component)|\(.affected_versions | join(","))")
-            | sort_by(.ecosystem, .component)
-          ' pkg/analyzer/data/blacklist.json /tmp/candidates.json > /tmp/merged-blacklist.json
-          mv /tmp/merged-blacklist.json pkg/analyzer/data/blacklist.json
+          mkdir -p .github/ioc-candidates/review
+          cp /tmp/candidates.json ".github/ioc-candidates/review/osv-${{ github.run_id }}.json"
 
       - name: Create pull request
         if: steps.candidate_count.outputs.count != '0'
@@ -69,10 +65,17 @@ jobs:
         with:
           token: ${{ secrets.TOOLTRUST_BOT_TOKEN || github.token }}
           branch: ioc-candidates/${{ github.run_id }}
-          title: "ioc: ${{ steps.candidate_count.outputs.count }} new compromise candidate(s)"
-          commit-message: "data(blacklist): auto-append ${{ steps.candidate_count.outputs.count }} OSV compromise candidate(s)"
+          title: "threat-intel: ${{ steps.candidate_count.outputs.count }} OSV candidate(s) for review"
+          commit-message: "threat-intel: add ${{ steps.candidate_count.outputs.count }} OSV candidate(s) for review"
           body: |
-            Automated IOC compromise candidates generated from OSV ecosystem feeds for the last 24 hours.
+            Automated OSV threat-intel candidates generated from ecosystem feeds for the last 24 hours.
+
+            This is a **review-only** PR. It intentionally does not modify:
+
+            - `pkg/analyzer/data/blacklist.json`
+            - `pkg/analyzer/data/npm_iocs.json`
+
+            Normal CVEs should remain covered by AS-004 / OSV and should not be promoted.
 
             Review each entry carefully:
             - Does this read like a real supply-chain compromise or malicious publish, rather than an ordinary CVE?
@@ -80,7 +83,15 @@ jobs:
             - Is `BLOCK` the right action, or should this be downgraded to `WARN`?
             - Is the reason clear enough for someone triaging a finding?
 
-            Close this PR if any candidate looks like a normal vulnerability that should stay in AS-004 / OSV instead of the manual blacklist.
+            If an entry is confirmed supply-chain compromise, copy it into a curated candidate file and run:
+
+            ```bash
+            go run ./cmd/tooltrust-ioc-promote <reviewed-candidate-json>
+            ```
+
+            Close this PR after triage unless it is intentionally converted into a curated data update.
           labels: |
             ioc
             automated
+          add-paths: |
+            .github/ioc-candidates/review/*.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
       - run: go test -race -count=1 ./...
 
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Set version from tag

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Install govulncheck
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Run gosec
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build tooltrust-scanner

--- a/docs/IOC_PIPELINE.md
+++ b/docs/IOC_PIPELINE.md
@@ -46,14 +46,21 @@ Supported npm IOC types currently include:
 ## Candidate Flow
 
 1. Threat-intel monitor opens an issue for a new incident or blog post and writes a draft candidate file under `.github/ioc-candidates/`.
-2. Maintainer extracts candidate IOCs into a structured candidate JSON file.
-3. Candidate is reviewed and classified:
+2. The daily OSV monitor may open a review-only PR with candidate JSON under `.github/ioc-candidates/review/`.
+3. Maintainer extracts candidate IOCs into a structured candidate JSON file.
+4. Candidate is reviewed and classified:
    - `promote_to: blacklist`
    - `promote_to: npm_iocs`
    - `promote_to: watch_only`
-4. Maintainer adds the reviewed entry to the scanner data file.
-5. Tests are updated to cover the new signal.
-6. A scanner release/tag is cut so ToolTrust Directory can consume the update.
+5. Maintainer adds the reviewed entry to the scanner data file.
+6. Tests are updated to cover the new signal.
+7. A scanner release/tag is cut so ToolTrust Directory can consume the update.
+
+The daily OSV monitor is intentionally not an automatic promotion path. It
+should not modify `pkg/analyzer/data/blacklist.json` or
+`pkg/analyzer/data/npm_iocs.json` directly. Normal CVEs remain covered by
+AS-004 / OSV and should not be promoted into AS-008 unless independent evidence
+confirms a malicious publish or supply-chain compromise.
 
 ## Promotion Helper
 
@@ -127,6 +134,8 @@ Keep as `watch_only` when:
 - attribution is weak
 - only one unverified report exists
 - the signal is too noisy for scanner enforcement
+- the advisory is a normal CVE/RCE/IDOR/sandbox escape/hardcoded secret without
+  evidence of malicious or compromised package publication
 
 ## What This Does Not Cover Yet
 

--- a/docs/github-actions-scan.yml
+++ b/docs/github-actions-scan.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Install ToolTrust Scanner

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/AgentSafe-AI/tooltrust-scanner
 
 go 1.26
 
-toolchain go1.26.1
+toolchain go1.26.4
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/scripts/ioc-candidates/fetch.go
+++ b/scripts/ioc-candidates/fetch.go
@@ -38,14 +38,21 @@ type config struct {
 }
 
 type blacklistEntry struct {
-	ID               string   `json:"id"`
-	Component        string   `json:"component"`
 	Ecosystem        string   `json:"ecosystem"`
-	AffectedVersions []string `json:"affected_versions"`
-	Action           string   `json:"action"`
-	Severity         string   `json:"severity"`
+	IOCType          string   `json:"ioc_type"`
+	Value            string   `json:"value"`
+	Component        string   `json:"component,omitempty"`
+	Confidence       string   `json:"confidence"`
 	Reason           string   `json:"reason"`
-	Link             string   `json:"link"`
+	Source           string   `json:"source"`
+	FirstSeen        string   `json:"first_seen"`
+	SuggestedAction  string   `json:"suggested_action"`
+	PromoteTo        string   `json:"promote_to"`
+	BlacklistID      string   `json:"blacklist_id,omitempty"`
+	AffectedVersions []string `json:"affected_versions,omitempty"`
+	Action           string   `json:"action,omitempty"`
+	Severity         string   `json:"severity,omitempty"`
+	Notes            string   `json:"notes,omitempty"`
 }
 
 type osvVulnerability struct {
@@ -185,7 +192,7 @@ func fetchCandidatesWithClient(ctx context.Context, cfg config, client httpDoer,
 
 	sort.Slice(allCandidates, func(i, j int) bool {
 		if strings.EqualFold(allCandidates[i].Ecosystem, allCandidates[j].Ecosystem) {
-			return strings.ToLower(allCandidates[i].Component) < strings.ToLower(allCandidates[j].Component)
+			return strings.ToLower(allCandidates[i].Value) < strings.ToLower(allCandidates[j].Value)
 		}
 		return strings.ToLower(allCandidates[i].Ecosystem) < strings.ToLower(allCandidates[j].Ecosystem)
 	})
@@ -314,14 +321,20 @@ func buildCandidates(vulns []osvVulnerability, ecosystem string, existing map[st
 			}
 
 			entry := blacklistEntry{
-				ID:               preferredID(*vuln),
-				Component:        component,
 				Ecosystem:        ecosystem,
+				IOCType:          "package_name",
+				Value:            component,
+				Confidence:       candidateConfidence(*vuln),
+				Reason:           truncateReason(firstNonEmpty(strings.TrimSpace(vuln.Summary), strings.TrimSpace(vuln.Details)), 200),
+				Source:           fmt.Sprintf("https://osv.dev/vulnerability/%s", vuln.ID),
+				FirstSeen:        published.Format("2006-01-02"),
+				SuggestedAction:  suggestedActionForCandidate(*vuln),
+				PromoteTo:        "watch_only",
+				BlacklistID:      preferredID(*vuln),
 				AffectedVersions: filtered,
 				Action:           "BLOCK",
 				Severity:         severity,
-				Reason:           truncateReason(firstNonEmpty(strings.TrimSpace(vuln.Summary), strings.TrimSpace(vuln.Details)), 200),
-				Link:             fmt.Sprintf("https://osv.dev/vulnerability/%s", vuln.ID),
+				Notes:            candidateNotes(*vuln),
 			}
 			seenKey := candidateKey(entry)
 			if _, exists := seen[seenKey]; exists {
@@ -335,38 +348,75 @@ func buildCandidates(vulns []osvVulnerability, ecosystem string, existing map[st
 }
 
 func looksLikeBlacklistCandidate(vuln osvVulnerability) bool {
+	return hasStrongCompromiseSignal(vuln)
+}
+
+func candidateConfidence(vuln osvVulnerability) string {
+	if hasStrongCompromiseSignal(vuln) {
+		return "high"
+	}
+	return "medium"
+}
+
+func suggestedActionForCandidate(vuln osvVulnerability) string {
+	if hasStrongCompromiseSignal(vuln) {
+		return "block"
+	}
+	return "watch"
+}
+
+func candidateNotes(vuln osvVulnerability) string {
+	if hasStrongCompromiseSignal(vuln) {
+		return "Review before promotion. Promote to blacklist only after confirming malicious or compromised affected versions."
+	}
+	return "Review-only OSV candidate. Do not promote to AS-008 unless independent evidence confirms a malicious publish or supply-chain compromise."
+}
+
+func hasStrongCompromiseSignal(vuln osvVulnerability) bool {
 	text := strings.ToLower(strings.Join([]string{
 		strings.TrimSpace(vuln.Summary),
 		strings.TrimSpace(vuln.Details),
 		strings.Join(vuln.Aliases, " "),
 	}, " "))
-	if text == "" {
-		return false
-	}
 
-	signals := []string{
-		"compromised",
-		"malicious",
-		"supply chain",
-		"supply-chain",
-		"credential exfiltration",
-		"exfiltration routine",
-		"maintainer",
+	strongSignals := []string{
+		"compromised package",
+		"compromised release",
+		"compromised version",
+		"malicious package",
+		"malicious publish",
+		"malicious release",
+		"malicious version",
+		"supply-chain compromise",
+		"supply chain compromise",
 		"account takeover",
-		"hijack",
-		"hijacked",
-		"backdoor",
-		"protestware",
+		"maintainer account",
+		"stolen npm token",
+		"stolen release token",
+		"credential exfiltration",
+		"exfiltrate credentials",
+		"backdoored package",
+		"backdoored release",
 		"dependency confusion",
-		"typosquat",
-		"typosquatting",
 		"poisoned package",
 		"poisoned release",
-		"stolen release token",
-		"malicious dependency",
+		"protestware",
+		"typosquat",
+		"typosquatting",
 	}
-	for _, signal := range signals {
+	for _, signal := range strongSignals {
 		if strings.Contains(text, signal) {
+			return true
+		}
+	}
+	tokenPairs := [][2]string{
+		{"compromised", "package"},
+		{"compromised", "release"},
+		{"malicious", "dependency"},
+		{"malicious", "publish"},
+	}
+	for _, pair := range tokenPairs {
+		if strings.Contains(text, pair[0]) && strings.Contains(text, pair[1]) {
 			return true
 		}
 	}
@@ -386,7 +436,7 @@ func readExistingBlacklist(path string) (map[string]struct{}, error) {
 	for i := range entries {
 		entry := entries[i]
 		for _, version := range entry.AffectedVersions {
-			key := strings.ToLower(entry.Ecosystem) + ":" + strings.ToLower(entry.Component) + "@" + version
+			key := strings.ToLower(entry.Ecosystem) + ":" + strings.ToLower(firstNonEmpty(entry.Value, entry.Component)) + "@" + version
 			seen[key] = struct{}{}
 		}
 	}
@@ -526,7 +576,7 @@ func firstNonEmpty(values ...string) string {
 }
 
 func candidateKey(entry blacklistEntry) string {
-	return strings.ToLower(entry.Ecosystem) + "|" + strings.ToLower(entry.Component) + "|" + strings.Join(entry.AffectedVersions, ",")
+	return strings.ToLower(entry.Ecosystem) + "|" + strings.ToLower(firstNonEmpty(entry.Value, entry.Component)) + "|" + strings.Join(entry.AffectedVersions, ",")
 }
 
 func dedupeCandidates(entries []blacklistEntry) []blacklistEntry {

--- a/scripts/ioc-candidates/fetch_test.go
+++ b/scripts/ioc-candidates/fetch_test.go
@@ -33,13 +33,45 @@ func TestBuildCandidates_Golden(t *testing.T) {
 	}
 	for i := range want {
 		if candidateKey(got[i]) != candidateKey(want[i]) ||
-			got[i].ID != want[i].ID ||
+			got[i].BlacklistID != want[i].BlacklistID ||
+			got[i].IOCType != want[i].IOCType ||
+			got[i].Confidence != want[i].Confidence ||
+			got[i].Source != want[i].Source ||
+			got[i].FirstSeen != want[i].FirstSeen ||
+			got[i].SuggestedAction != want[i].SuggestedAction ||
+			got[i].PromoteTo != want[i].PromoteTo ||
 			got[i].Severity != want[i].Severity ||
 			got[i].Action != want[i].Action ||
 			got[i].Reason != want[i].Reason ||
-			got[i].Link != want[i].Link {
+			got[i].Notes != want[i].Notes {
 			t.Fatalf("candidate %d mismatch:\n got: %#v\nwant: %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func TestBuildCandidates_SkipsOrdinaryCVEsWithMaliciousUserWording(t *testing.T) {
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	vulns := []osvVulnerability{
+		{
+			ID:        "GHSA-praison-2026-0001",
+			Summary:   "praisonai-platform: hardcoded JWT signing key allows token forgery by a malicious user.",
+			Published: "2026-06-01T18:00:00Z",
+			Severity:  []osvSeverity{{Type: "CVSS_V3", Score: "9.1"}},
+			Affected: []osvAffected{
+				{
+					Package: struct {
+						Name      string `json:"name"`
+						Ecosystem string `json:"ecosystem"`
+					}{Name: "praisonai-platform", Ecosystem: "PyPI"},
+					Versions: []string{"0.1.0"},
+				},
+			},
+		},
+	}
+
+	got := buildCandidates(vulns, "PyPI", map[string]struct{}{}, now, 24*time.Hour, "HIGH")
+	if len(got) != 0 {
+		t.Fatalf("ordinary CVE should not produce an IOC review PR candidate, got %#v", got)
 	}
 }
 

--- a/scripts/ioc-candidates/testdata/candidates-expected.json
+++ b/scripts/ioc-candidates/testdata/candidates-expected.json
@@ -1,12 +1,21 @@
 [
   {
-    "id": "GHSA-axios-2026-0001",
-    "component": "axios",
     "ecosystem": "npm",
-    "affected_versions": ["0.30.4", "1.14.1"],
+    "ioc_type": "package_name",
+    "value": "axios",
+    "confidence": "high",
+    "reason": "Compromised axios release shipped with a malicious dependency.",
+    "source": "https://osv.dev/vulnerability/GHSA-axios-2026-0001",
+    "first_seen": "2026-04-21",
+    "suggested_action": "block",
+    "promote_to": "watch_only",
+    "blacklist_id": "GHSA-axios-2026-0001",
+    "affected_versions": [
+      "0.30.4",
+      "1.14.1"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
-    "reason": "Compromised axios release shipped with a malicious dependency.",
-    "link": "https://osv.dev/vulnerability/GHSA-axios-2026-0001"
+    "notes": "Review before promotion. Promote to blacklist only after confirming malicious or compromised affected versions."
   }
 ]


### PR DESCRIPTION
## Summary
- change the daily OSV IOC workflow to create review-only candidate artifacts instead of mutating blacklist data
- emit candidates under .github/ioc-candidates/review/ with explicit promotion instructions
- tighten OSV candidate matching so ordinary CVEs with phrases like 'malicious user' do not create IOC PR noise
- document the manual promotion workflow and keep normal CVEs in AS-004/OSV

## Validation
- go test ./scripts/ioc-candidates
- go test ./...
- git diff --check
- YAML parse for .github/workflows/ioc-candidates.yml