### PR TITLE
threat-intel: 2 OSV candidate(s) for review

### DIFF
--- a/.github/ioc-candidates/review/osv-27061364748.json
+++ b/.github/ioc-candidates/review/osv-27061364748.json
@@ -1,0 +1,58 @@
+[
+  {
+    "ecosystem": "PyPI",
+    "ioc_type": "package_name",
+    "value": "ait-core",
+    "confidence": "high",
+    "reason": "NASA AMMOS Instrument Toolkit: Path traversal resulting in arbitrary file append (can be triggered over the network by unauthenticated attacker)",
+    "source": "https://osv.dev/vulnerability/GHSA-p462-prxw-mjx4",
+    "first_seen": "2026-06-05",
+    "suggested_action": "block",
+    "promote_to": "watch_only",
+    "blacklist_id": "CVE-2026-47731",
+    "affected_versions": [
+      "3.1.0"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "notes": "Review before promotion. Promote to blacklist only after confirming malicious or compromised affected versions."
+  },
+  {
+    "ecosystem": "PyPI",
+    "ioc_type": "package_name",
+    "value": "ait-core",
+    "confidence": "high",
+    "reason": "NASA AMMOS Instrument Toolkit: Path traversal resulting in arbitrary file append (can be triggered over the network by unauthenticated attacker)",
+    "source": "https://osv.dev/vulnerability/GHSA-p462-prxw-mjx4",
+    "first_seen": "2026-06-05",
+    "suggested_action": "block",
+    "promote_to": "watch_only",
+    "blacklist_id": "CVE-2026-47731",
+    "affected_versions": [
+      "1.0.0",
+      "1.1.0",
+      "1.2.0",
+      "1.3.0",
+      "1.4.0",
+      "2.0.0",
+      "2.0.1",
+      "2.0rc1.dev0",
+      "2.1.0",
+      "2.2.0",
+      "2.3.0",
+      "2.3.1",
+      "2.3.2",
+      "2.3.3",
+      "2.3.4",
+      "2.3.5",
+      "2.4.0",
+      "2.5.0",
+      "2.5.1",
+      "2.5.2",
+      "2.6.0"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "notes": "Review before promotion. Promote to blacklist only after confirming malicious or compromised affected versions."
+  }
+]


### PR DESCRIPTION
Automated OSV threat-intel candidates generated from ecosystem feeds for the last 24 hours.

This is a **review-only** PR. It intentionally does not modify:

- `pkg/analyzer/data/blacklist.json`
- `pkg/analyzer/data/npm_iocs.json`

Normal CVEs should remain covered by AS-004 / OSV and should not be promoted.

Review each entry carefully:
- Does this read like a real supply-chain compromise or malicious publish, rather than an ordinary CVE?
- Is the version pinning exact and narrow enough?
- Is `BLOCK` the right action, or should this be downgraded to `WARN`?
- Is the reason clear enough for someone triaging a finding?

If an entry is confirmed supply-chain compromise, copy it into a curated candidate file and run:

```bash
go run ./cmd/tooltrust-ioc-promote <reviewed-candidate-json>
```

Close this PR after triage unless it is intentionally converted into a curated data update.