### PR TITLE
ci: tighten IOC candidate compromise signals

### DIFF
--- a/scripts/ioc-candidates/fetch.go
+++ b/scripts/ioc-candidates/fetch.go
@@ -398,6 +398,7 @@ func hasStrongCompromiseSignal(vuln osvVulnerability) bool {
 		"backdoored package",
 		"backdoored release",
 		"dependency confusion",
+		"malicious dependency",
 		"poisoned package",
 		"poisoned release",
 		"protestware",
@@ -406,17 +407,6 @@ func hasStrongCompromiseSignal(vuln osvVulnerability) bool {
 	}
 	for _, signal := range strongSignals {
 		if strings.Contains(text, signal) {
-			return true
-		}
-	}
-	tokenPairs := [][2]string{
-		{"compromised", "package"},
-		{"compromised", "release"},
-		{"malicious", "dependency"},
-		{"malicious", "publish"},
-	}
-	for _, pair := range tokenPairs {
-		if strings.Contains(text, pair[0]) && strings.Contains(text, pair[1]) {
 			return true
 		}
 	}

--- a/scripts/ioc-candidates/fetch_test.go
+++ b/scripts/ioc-candidates/fetch_test.go
@@ -75,6 +75,34 @@ func TestBuildCandidates_SkipsOrdinaryCVEsWithMaliciousUserWording(t *testing.T)
 	}
 }
 
+func TestBuildCandidates_SkipsOrdinaryCVEsWithCompromiseAndPackageWording(t *testing.T) {
+	now := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	vulns := []osvVulnerability{
+		{
+			ID:        "GHSA-p462-prxw-mjx4",
+			Summary:   "NASA AMMOS Instrument Toolkit: Path traversal resulting in arbitrary file append.",
+			Details:   "The package can be used by an unauthenticated attacker to compromise application files over the network.",
+			Published: "2026-06-05T18:00:00Z",
+			Aliases:   []string{"CVE-2026-47731"},
+			Severity:  []osvSeverity{{Type: "CVSS_V3", Score: "9.8"}},
+			Affected: []osvAffected{
+				{
+					Package: struct {
+						Name      string `json:"name"`
+						Ecosystem string `json:"ecosystem"`
+					}{Name: "ait-core", Ecosystem: "PyPI"},
+					Versions: []string{"2.5.2"},
+				},
+			},
+		},
+	}
+
+	got := buildCandidates(vulns, "PyPI", map[string]struct{}{}, now, 24*time.Hour, "HIGH")
+	if len(got) != 0 {
+		t.Fatalf("ordinary CVE should not produce an IOC review PR candidate, got %#v", got)
+	}
+}
+
 func TestFetchCandidatesWithClient_FeedFailureIsWarning(t *testing.T) {
 	cfg := config{
 		Since:       24 * time.Hour,

--- a/scripts/ioc-candidates/fetch_test.go
+++ b/scripts/ioc-candidates/fetch_test.go
@@ -75,6 +75,15 @@ func TestBuildCandidates_SkipsOrdinaryCVEsWithMaliciousUserWording(t *testing.T)
 	}
 }
 
+func TestHasStrongCompromiseSignal_MaliciousDependencyPhrase(t *testing.T) {
+	vuln := osvVulnerability{
+		Summary: "pkg: ships a malicious dependency that exfiltrates credentials",
+	}
+	if !hasStrongCompromiseSignal(vuln) {
+		t.Fatal("expected 'malicious dependency' phrase to trigger strong compromise signal")
+	}
+}
+
 func TestBuildCandidates_SkipsOrdinaryCVEsWithCompromiseAndPackageWording(t *testing.T) {
 	now := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
 	vulns := []osvVulnerability{


### PR DESCRIPTION
## Summary
- close the gap exposed by PR #46 where ordinary CVE language could enter the IOC review queue
- remove loose token-pair matching such as compromised + package
- keep exact supply-chain phrases like malicious dependency
- add a regression test for ordinary CVEs with compromise/package wording

## Validation
- go test ./scripts/ioc-candidates
- go test ./...
- git diff --check