### PR TITLE
data: blacklist openai-mcp + tiktoken-mcp (MCP supply-chain IOCs)

### DIFF
--- a/pkg/analyzer/data/blacklist.json
+++ b/pkg/analyzer/data/blacklist.json
@@ -1,19 +1,13 @@
 [
   {
-    "id": "SNYK-PYTHON-LITELLM-15762713",
-    "component": "litellm",
-    "ecosystem": "PyPI",
-    "affected_versions": ["1.82.7", "1.82.8"],
-    "action": "BLOCK",
-    "severity": "CRITICAL",
-    "reason": "TeamPCP supply chain attack: malicious .pth file steals SSH keys, AWS/K8s credentials and .env files on every Python startup, then establishes systemd persistence and attempts Kubernetes lateral movement.",
-    "link": "https://security.snyk.io/vuln/SNYK-PYTHON-LITELLM-15762713"
-  },
-  {
     "id": "GHSA-69fq-xp46-6x23",
     "component": "trivy",
     "ecosystem": "binary",
-    "affected_versions": ["v0.69.4", "v0.69.5", "v0.69.6"],
+    "affected_versions": [
+      "v0.69.4",
+      "v0.69.5",
+      "v0.69.6"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "TeamPCP compromised CI/CD pipeline and pushed malicious binaries that exfiltrate runner memory and environment secrets.",
@@ -21,49 +15,35 @@
   },
   {
     "id": "GHSA-69fq-xp46-6x23",
-    "component": "trivy-action",
-    "ecosystem": "github-actions",
-    "affected_versions": ["< v0.35.0"],
-    "action": "WARN",
-    "severity": "HIGH",
-    "reason": "Vulnerable tags were force-pushed to point to malicious commits during the March 2026 TeamPCP exposure window. Upgrade to v0.35.0+ and pin by SHA.",
-    "link": "https://github.com/aquasecurity/trivy-action/security/advisories"
-  },
-  {
-    "id": "GHSA-69fq-xp46-6x23",
     "component": "setup-trivy",
     "ecosystem": "github-actions",
-    "affected_versions": ["< v0.2.6"],
+    "affected_versions": [
+      "\u003c v0.2.6"
+    ],
     "action": "WARN",
     "severity": "HIGH",
     "reason": "Versions prior to v0.2.6 were at elevated risk during the March 2026 TeamPCP exposure window (~4 hours). Upgrade to v0.2.6+ (SHA: 3fb12ec) or pin by digest.",
     "link": "https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23"
   },
   {
-    "id": "CVE-2026-33017",
-    "component": "langflow",
-    "ecosystem": "PyPI",
-    "affected_versions": ["< 1.9.0"],
-    "action": "BLOCK",
-    "severity": "CRITICAL",
-    "reason": "Unauthenticated RCE (CVSS 9.8): POST /api/v1/build_public_tmp/{flow_id}/flow accepts attacker-controlled flow data and passes arbitrary Python code directly to exec() with no sandboxing. Fixed in 1.9.0.",
-    "link": "https://github.com/advisories/GHSA-rvqx-wpfh-mfx7"
-  },
-  {
-    "id": "AXIOS-NPM-COMPROMISE-2026-03-31",
-    "component": "axios",
-    "ecosystem": "npm",
-    "affected_versions": ["1.14.1", "0.30.4"],
-    "action": "BLOCK",
-    "severity": "CRITICAL",
-    "reason": "Confirmed npm supply-chain compromise: attacker reportedly hijacked the maintainer npm account and published malicious axios builds that introduced the plain-crypto-js dependency outside the normal GitHub Actions release flow.",
-    "link": "https://github.com/axios/axios"
+    "id": "GHSA-69fq-xp46-6x23",
+    "component": "trivy-action",
+    "ecosystem": "github-actions",
+    "affected_versions": [
+      "\u003c v0.35.0"
+    ],
+    "action": "WARN",
+    "severity": "HIGH",
+    "reason": "Vulnerable tags were force-pushed to point to malicious commits during the March 2026 TeamPCP exposure window. Upgrade to v0.35.0+ and pin by SHA.",
+    "link": "https://github.com/aquasecurity/trivy-action/security/advisories"
   },
   {
     "id": "BITWARDEN-CLI-COMPROMISE-2026-04-22",
     "component": "@bitwarden/cli",
     "ecosystem": "npm",
-    "affected_versions": ["2026.4.0"],
+    "affected_versions": [
+      "2026.4.0"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Confirmed npm supply-chain compromise: attackers hijacked Bitwarden's GitHub Actions, stole release secrets, and pushed a tampered @bitwarden/cli@2026.4.0 build to npm containing malicious code. Remove immediately and rotate any credentials that passed through the CLI.",
@@ -73,7 +53,9 @@
     "id": "CVE-2026-46421",
     "component": "@cap-js/db-service",
     "ecosystem": "npm",
-    "affected_versions": ["2.10.1"],
+    "affected_versions": [
+      "2.10.1"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Confirmed npm supply-chain compromise: malicious @cap-js package versions were published as part of a coordinated compromise across @cap-js/sqlite, @cap-js/postgres, and @cap-js/db-service.",
@@ -83,7 +65,9 @@
     "id": "CVE-2026-46421",
     "component": "@cap-js/postgres",
     "ecosystem": "npm",
-    "affected_versions": ["2.2.2"],
+    "affected_versions": [
+      "2.2.2"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Confirmed npm supply-chain compromise: malicious @cap-js package versions were published as part of a coordinated compromise across @cap-js/sqlite, @cap-js/postgres, and @cap-js/db-service.",
@@ -93,17 +77,37 @@
     "id": "CVE-2026-46421",
     "component": "@cap-js/sqlite",
     "ecosystem": "npm",
-    "affected_versions": ["2.2.2"],
+    "affected_versions": [
+      "2.2.2"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Confirmed npm supply-chain compromise: malicious @cap-js package versions were published as part of a coordinated compromise across @cap-js/sqlite, @cap-js/postgres, and @cap-js/db-service.",
     "link": "https://osv.dev/vulnerability/GHSA-pvw4-cvr4-97p8"
   },
   {
+    "id": "MINI-SHAI-HULUD-2026-05-11",
+    "component": "@opensearch-project/opensearch",
+    "ecosystem": "npm",
+    "affected_versions": [
+      "3.5.3",
+      "3.6.2",
+      "3.7.0",
+      "3.8.0"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud supply-chain compromise: confirmed malicious package artifacts tied to credential theft and remote payload execution across npm/PyPI ecosystems.",
+    "link": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack"
+  },
+  {
     "id": "CVE-2026-45321",
     "component": "@tanstack/arktype-adapter",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.12", "1.166.15"],
+    "affected_versions": [
+      "1.166.12",
+      "1.166.15"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -113,7 +117,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/eslint-plugin-router",
     "ecosystem": "npm",
-    "affected_versions": ["1.161.9", "1.161.12"],
+    "affected_versions": [
+      "1.161.9",
+      "1.161.12"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -123,7 +130,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/eslint-plugin-start",
     "ecosystem": "npm",
-    "affected_versions": ["0.0.4", "0.0.7"],
+    "affected_versions": [
+      "0.0.4",
+      "0.0.7"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -133,7 +143,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/history",
     "ecosystem": "npm",
-    "affected_versions": ["1.161.9", "1.161.12"],
+    "affected_versions": [
+      "1.161.9",
+      "1.161.12"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -143,7 +156,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/nitro-v2-vite-plugin",
     "ecosystem": "npm",
-    "affected_versions": ["1.154.12", "1.154.15"],
+    "affected_versions": [
+      "1.154.12",
+      "1.154.15"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -153,7 +169,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-router",
     "ecosystem": "npm",
-    "affected_versions": ["1.169.5", "1.169.8"],
+    "affected_versions": [
+      "1.169.5",
+      "1.169.8"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -163,7 +182,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-router-devtools",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.16", "1.166.19"],
+    "affected_versions": [
+      "1.166.16",
+      "1.166.19"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -173,7 +195,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-router-ssr-query",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.15", "1.166.18"],
+    "affected_versions": [
+      "1.166.15",
+      "1.166.18"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -183,7 +208,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-start",
     "ecosystem": "npm",
-    "affected_versions": ["1.167.68", "1.167.71"],
+    "affected_versions": [
+      "1.167.68",
+      "1.167.71"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -193,7 +221,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-start-client",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.51", "1.166.54"],
+    "affected_versions": [
+      "1.166.51",
+      "1.166.54"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -203,7 +234,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-start-rsc",
     "ecosystem": "npm",
-    "affected_versions": ["0.0.47", "0.0.50"],
+    "affected_versions": [
+      "0.0.47",
+      "0.0.50"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -213,7 +247,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/react-start-server",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.55", "1.166.58"],
+    "affected_versions": [
+      "1.166.55",
+      "1.166.58"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -223,7 +260,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-cli",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.46", "1.166.49"],
+    "affected_versions": [
+      "1.166.46",
+      "1.166.49"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -233,7 +273,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-core",
     "ecosystem": "npm",
-    "affected_versions": ["1.169.5", "1.169.8"],
+    "affected_versions": [
+      "1.169.5",
+      "1.169.8"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -243,7 +286,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-devtools",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.16", "1.166.19"],
+    "affected_versions": [
+      "1.166.16",
+      "1.166.19"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -253,7 +299,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-devtools-core",
     "ecosystem": "npm",
-    "affected_versions": ["1.167.6", "1.167.9"],
+    "affected_versions": [
+      "1.167.6",
+      "1.167.9"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -263,7 +312,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-generator",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.45", "1.166.48"],
+    "affected_versions": [
+      "1.166.45",
+      "1.166.48"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -273,7 +325,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-plugin",
     "ecosystem": "npm",
-    "affected_versions": ["1.167.38", "1.167.41"],
+    "affected_versions": [
+      "1.167.38",
+      "1.167.41"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -283,7 +338,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-ssr-query-core",
     "ecosystem": "npm",
-    "affected_versions": ["1.168.3", "1.168.6"],
+    "affected_versions": [
+      "1.168.3",
+      "1.168.6"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -293,7 +351,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-utils",
     "ecosystem": "npm",
-    "affected_versions": ["1.161.11", "1.161.14"],
+    "affected_versions": [
+      "1.161.11",
+      "1.161.14"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -303,7 +364,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/router-vite-plugin",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.53", "1.166.56"],
+    "affected_versions": [
+      "1.166.53",
+      "1.166.56"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -313,7 +377,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/solid-router",
     "ecosystem": "npm",
-    "affected_versions": ["1.169.5", "1.169.8"],
+    "affected_versions": [
+      "1.169.5",
+      "1.169.8"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -323,7 +390,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/solid-router-devtools",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.16", "1.166.19"],
+    "affected_versions": [
+      "1.166.16",
+      "1.166.19"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -333,7 +403,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/solid-router-ssr-query",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.15", "1.166.18"],
+    "affected_versions": [
+      "1.166.15",
+      "1.166.18"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -343,7 +416,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/solid-start",
     "ecosystem": "npm",
-    "affected_versions": ["1.167.65", "1.167.68"],
+    "affected_versions": [
+      "1.167.65",
+      "1.167.68"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -353,7 +429,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/solid-start-client",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.50", "1.166.53"],
+    "affected_versions": [
+      "1.166.50",
+      "1.166.53"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -363,7 +442,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/solid-start-server",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.54", "1.166.57"],
+    "affected_versions": [
+      "1.166.54",
+      "1.166.57"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -373,7 +455,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/start-client-core",
     "ecosystem": "npm",
-    "affected_versions": ["1.168.5", "1.168.8"],
+    "affected_versions": [
+      "1.168.5",
+      "1.168.8"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -383,7 +468,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/start-fn-stubs",
     "ecosystem": "npm",
-    "affected_versions": ["1.161.9", "1.161.12"],
+    "affected_versions": [
+      "1.161.9",
+      "1.161.12"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -393,7 +481,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/start-plugin-core",
     "ecosystem": "npm",
-    "affected_versions": ["1.169.23", "1.169.26"],
+    "affected_versions": [
+      "1.169.23",
+      "1.169.26"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -403,7 +494,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/start-server-core",
     "ecosystem": "npm",
-    "affected_versions": ["1.167.33", "1.167.36"],
+    "affected_versions": [
+      "1.167.33",
+      "1.167.36"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -413,7 +507,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/start-static-server-functions",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.44", "1.166.47"],
+    "affected_versions": [
+      "1.166.44",
+      "1.166.47"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -423,7 +520,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/start-storage-context",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.38", "1.166.41"],
+    "affected_versions": [
+      "1.166.38",
+      "1.166.41"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -433,7 +533,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/valibot-adapter",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.12", "1.166.15"],
+    "affected_versions": [
+      "1.166.12",
+      "1.166.15"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -443,7 +546,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/virtual-file-routes",
     "ecosystem": "npm",
-    "affected_versions": ["1.161.10", "1.161.13"],
+    "affected_versions": [
+      "1.161.10",
+      "1.161.13"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -453,7 +559,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/vue-router",
     "ecosystem": "npm",
-    "affected_versions": ["1.169.5", "1.169.8"],
+    "affected_versions": [
+      "1.169.5",
+      "1.169.8"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -463,7 +572,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/vue-router-devtools",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.16", "1.166.19"],
+    "affected_versions": [
+      "1.166.16",
+      "1.166.19"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -473,7 +585,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/vue-router-ssr-query",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.15", "1.166.18"],
+    "affected_versions": [
+      "1.166.15",
+      "1.166.18"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -483,7 +598,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/vue-start",
     "ecosystem": "npm",
-    "affected_versions": ["1.167.61", "1.167.64"],
+    "affected_versions": [
+      "1.167.61",
+      "1.167.64"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -493,7 +611,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/vue-start-client",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.46", "1.166.49"],
+    "affected_versions": [
+      "1.166.46",
+      "1.166.49"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -503,7 +624,10 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/vue-start-server",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.50", "1.166.53"],
+    "affected_versions": [
+      "1.166.50",
+      "1.166.53"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
@@ -513,40 +637,101 @@
     "id": "CVE-2026-45321",
     "component": "@tanstack/zod-adapter",
     "ecosystem": "npm",
-    "affected_versions": ["1.166.12", "1.166.15"],
+    "affected_versions": [
+      "1.166.12",
+      "1.166.15"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud / TanStack supply-chain compromise: malicious npm package versions execute an obfuscated router_init.js payload that harvests cloud, GitHub, npm, Kubernetes, Vault, and SSH credentials and propagates through npm publishing workflows.",
     "link": "https://github.com/advisories/GHSA-g7cv-rxg3-hmpx"
   },
   {
-    "id": "MINI-SHAI-HULUD-2026-05-11",
-    "component": "@opensearch-project/opensearch",
+    "id": "AXIOS-NPM-COMPROMISE-2026-03-31",
+    "component": "axios",
     "ecosystem": "npm",
-    "affected_versions": ["3.5.3", "3.6.2", "3.7.0", "3.8.0"],
+    "affected_versions": [
+      "1.14.1",
+      "0.30.4"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
-    "reason": "Mini Shai-Hulud supply-chain compromise: confirmed malicious package artifacts tied to credential theft and remote payload execution across npm/PyPI ecosystems.",
+    "reason": "Confirmed npm supply-chain compromise: attacker reportedly hijacked the maintainer npm account and published malicious axios builds that introduced the plain-crypto-js dependency outside the normal GitHub Actions release flow.",
+    "link": "https://github.com/axios/axios"
+  },
+  {
+    "id": "MINI-SHAI-HULUD-2026-05-11",
+    "component": "guardrails-ai",
+    "ecosystem": "PyPI",
+    "affected_versions": [
+      "0.10.1"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Mini Shai-Hulud supply-chain compromise: compromised PyPI release downloads a remote Python artifact and executes it without integrity verification.",
     "link": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack"
+  },
+  {
+    "id": "CVE-2026-33017",
+    "component": "langflow",
+    "ecosystem": "PyPI",
+    "affected_versions": [
+      "\u003c 1.9.0"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Unauthenticated RCE (CVSS 9.8): POST /api/v1/build_public_tmp/{flow_id}/flow accepts attacker-controlled flow data and passes arbitrary Python code directly to exec() with no sandboxing. Fixed in 1.9.0.",
+    "link": "https://github.com/advisories/GHSA-rvqx-wpfh-mfx7"
+  },
+  {
+    "id": "SNYK-PYTHON-LITELLM-15762713",
+    "component": "litellm",
+    "ecosystem": "PyPI",
+    "affected_versions": [
+      "1.82.7",
+      "1.82.8"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "TeamPCP supply chain attack: malicious .pth file steals SSH keys, AWS/K8s credentials and .env files on every Python startup, then establishes systemd persistence and attempts Kubernetes lateral movement.",
+    "link": "https://security.snyk.io/vuln/SNYK-PYTHON-LITELLM-15762713"
   },
   {
     "id": "MINI-SHAI-HULUD-2026-05-11",
     "component": "mistralai",
     "ecosystem": "PyPI",
-    "affected_versions": ["2.4.6"],
+    "affected_versions": [
+      "2.4.6"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
     "reason": "Mini Shai-Hulud supply-chain compromise: compromised PyPI release reportedly downloads and executes a secondary payload on Linux systems and targets developer credentials.",
     "link": "https://thehackernews.com/2026/05/tanstack-supply-chain-attack-hits-two.html"
   },
   {
-    "id": "MINI-SHAI-HULUD-2026-05-11",
-    "component": "guardrails-ai",
+    "id": "MAL-2026-5320",
+    "component": "openai-mcp",
     "ecosystem": "PyPI",
-    "affected_versions": ["0.10.1"],
+    "affected_versions": [
+      "2.41.1",
+      "2.41.2"
+    ],
     "action": "BLOCK",
     "severity": "CRITICAL",
-    "reason": "Mini Shai-Hulud supply-chain compromise: compromised PyPI release downloads a remote Python artifact and executes it without integrity verification.",
-    "link": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack"
+    "reason": "Malicious PyPI package impersonating an OpenAI MCP server. OSV-confirmed (MAL-2026-5320), reported by Kamil Mankowski. A developer intending to install an official OpenAI MCP integration who installs openai-mcp is compromised. See source for analysis.",
+    "link": "https://osv.dev/vulnerability/MAL-2026-5320"
+  },
+  {
+    "id": "MAL-2026-5326",
+    "component": "tiktoken-mcp",
+    "ecosystem": "PyPI",
+    "affected_versions": [
+      "0.13.1",
+      "0.13.2"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "reason": "Malicious PyPI package impersonating a tiktoken MCP tool. OSV-confirmed (MAL-2026-5326), reported by Kamil Mankowski. Targets developers wiring tiktoken/LLM tokenization into an MCP toolchain. See source for analysis.",
+    "link": "https://osv.dev/vulnerability/MAL-2026-5326"
   }
 ]


### PR DESCRIPTION
Promotes the two MCP/AI-relevant malicious packages from the OSV MAL- digest
(#50) into the AS-008 offline blacklist.

| package | versions | OSV | ecosystem |
|---|---|---|---|
| `openai-mcp` | 2.41.1, 2.41.2 | MAL-2026-5320 | PyPI |
| `tiktoken-mcp` | 0.13.1, 0.13.2 | MAL-2026-5326 | PyPI |

Both impersonate MCP/AI tooling — a developer installing what looks like an
OpenAI MCP server or a tiktoken MCP tool gets compromised. This is precisely
the supply-chain attack class ToolTrust exists to block, and the kind the new
OSV MAL- pipeline is meant to surface. OSV-confirmed, reported by Kamil
Mankowski.

These were the only 2 of 28 candidates across #50/#51 relevant to ToolTrust's
MCP scope; the rest are crypto typosquats already covered by AS-004's live OSV
lookup, and those review PRs are being closed.

**On the large diff:** the promote tool normalizes blacklist ordering. Verified
the existing 55 entries are unchanged (compared by ecosystem+component+versions,
0 removed, 0 modified) and only these 2 were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)