### PR TITLE
ci: make test check name version-stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,12 @@ jobs:
 
   # ── 1. Test ────────────────────────────────────────────────────────────────
   test:
-    name: Test (Go ${{ matrix.go }})
+    name: Test
     runs-on: ubuntu-latest
     needs: [source]
     permissions:
       id-token: write
       contents: read
-
-    strategy:
-      matrix:
-        go: ["1.26.4"]
 
     steps:
       - name: Download source tree
@@ -55,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: "1.26.4"
           cache: true
 
       - name: Download modules


### PR DESCRIPTION
Fixes the ruleset/CI check-name mismatch that forced --admin on every merge. Renames the test job check from `Test (Go 1.26.4)` to a stable `Test` (drops the single-value matrix), consistent with the Lint / ToolTrust Self-Scan jobs. The main ruleset's required context is updated to `Test` in a follow-up settings change after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)