### PR TITLE
chore: bump npm wrapper to v0.3.15 binary (1.1.10)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooltrust-mcp",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "MCP server that scans other MCP servers for prompt injection, data exfiltration, and privilege escalation. Add to your .mcp.json and let your AI agent audit its own tools.",
   "keywords": [
     "mcp",
@@ -21,5 +21,5 @@
     "tooltrust-mcp": "bin/run.js"
   },
   "mcpName": "io.github.AgentSafe-AI/tooltrust-scanner",
-  "tooltrustBinaryVersion": "v0.3.13"
+  "tooltrustBinaryVersion": "v0.3.15"
 }


### PR DESCRIPTION
## Summary

Updates the `tooltrust-mcp` npm wrapper to ship the **v0.3.15** scanner binary (the zero-FP tuning pass from #61) instead of the pinned **v0.3.13**.

- `tooltrustBinaryVersion`: `v0.3.13` → `v0.3.15`
- `version`: `1.1.9` → `1.1.10`

The wrapper (`npm/bin/run.js`) downloads `tooltrust-mcp_<goos>_<goarch>` from the GitHub release at `tooltrustBinaryVersion`; the v0.3.15 release is published and has all platform assets, so the download URL resolves.

## Publish note

There is no CI npm-publish step, so after merge `npm publish` from `npm/` is a **manual** step requiring npm auth. Until then, `npx tooltrust-mcp@latest` keeps serving 1.1.9 / v0.3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)