### PR TITLE
chore: bump npm wrapper to v0.3.16 binary (1.1.11)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooltrust-mcp",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "MCP server that scans other MCP servers for prompt injection, data exfiltration, and privilege escalation. Add to your .mcp.json and let your AI agent audit its own tools.",
   "keywords": [
     "mcp",
@@ -21,5 +21,5 @@
     "tooltrust-mcp": "bin/run.js"
   },
   "mcpName": "io.github.AgentSafe-AI/tooltrust-scanner",
-  "tooltrustBinaryVersion": "v0.3.15"
+  "tooltrustBinaryVersion": "v0.3.16"
 }


### PR DESCRIPTION
## Summary

Updates the `tooltrust-mcp` npm wrapper to ship the **v0.3.16** scanner binary (AS-004 host-dependency attribution fix, #64) instead of **v0.3.15**.

- `tooltrustBinaryVersion`: `v0.3.15` → `v0.3.16`
- `version`: `1.1.10` → `1.1.11`

The v0.3.16 GitHub release is published with all platform assets, so the wrapper's download URL resolves.

## Publish note

No CI npm-publish step exists — after merge, `npm publish` from `npm/` is a **manual** step requiring npm auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)