### PR TITLE
chore: bump npm wrapper to v0.3.17 binary (1.1.12)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooltrust-mcp",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "MCP server that scans other MCP servers for prompt injection, data exfiltration, and privilege escalation. Add to your .mcp.json and let your AI agent audit its own tools.",
   "keywords": [
     "mcp",
@@ -21,5 +21,5 @@
     "tooltrust-mcp": "bin/run.js"
   },
   "mcpName": "io.github.AgentSafe-AI/tooltrust-scanner",
-  "tooltrustBinaryVersion": "v0.3.16"
+  "tooltrustBinaryVersion": "v0.3.17"
 }


### PR DESCRIPTION
## Summary

Updates the `tooltrust-mcp` npm wrapper to ship the **v0.3.17** scanner binary (AS-002 capability-disclosure summary + AS-006 expression FP, #67) instead of v0.3.16.

- `tooltrustBinaryVersion`: `v0.3.16` → `v0.3.17`
- `version`: `1.1.11` → `1.1.12`

The v0.3.17 GitHub release is published with all platform assets.

## Publish note
No CI npm-publish step — after merge, `npm publish` from `npm/` is a **manual** step requiring npm auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)