### PR TITLE
threat-intel: 3 MCP/AI-relevant OSV-confirmed malicious package(s) for review

### DIFF
--- a/.github/ioc-candidates/review/osv-28378751594.json
+++ b/.github/ioc-candidates/review/osv-28378751594.json
@@ -1,0 +1,57 @@
+[
+  {
+    "ecosystem": "npm",
+    "ioc_type": "package_name",
+    "value": "checkmarx-claude-cache",
+    "confidence": "high",
+    "reason": "Malicious code in checkmarx-claude-cache (npm)",
+    "source": "https://osv.dev/vulnerability/MAL-2026-6576",
+    "first_seen": "2026-06-29",
+    "suggested_action": "block",
+    "promote_to": "watch_only",
+    "blacklist_id": "MAL-2026-6576",
+    "affected_versions": [
+      "1.0.0"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "notes": "OSV-confirmed malicious package (MAL-2026-6576). Reported by: amazon-inspector, Amazon Inspector. Review affected versions before promoting to AS-008."
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "package_name",
+    "value": "ollama-helpers",
+    "confidence": "high",
+    "reason": "Malicious code in ollama-helpers (npm)",
+    "source": "https://osv.dev/vulnerability/MAL-2026-6581",
+    "first_seen": "2026-06-29",
+    "suggested_action": "block",
+    "promote_to": "watch_only",
+    "blacklist_id": "MAL-2026-6581",
+    "affected_versions": [
+      "1.2.1",
+      "1.2.2"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "notes": "OSV-confirmed malicious package (MAL-2026-6581). Reported by: amazon-inspector, Amazon Inspector. Review affected versions before promoting to AS-008."
+  },
+  {
+    "ecosystem": "npm",
+    "ioc_type": "package_name",
+    "value": "openai-agents-helpers",
+    "confidence": "high",
+    "reason": "Malicious code in openai-agents-helpers (npm)",
+    "source": "https://osv.dev/vulnerability/MAL-2026-6582",
+    "first_seen": "2026-06-29",
+    "suggested_action": "block",
+    "promote_to": "watch_only",
+    "blacklist_id": "MAL-2026-6582",
+    "affected_versions": [
+      "1.3.2"
+    ],
+    "action": "BLOCK",
+    "severity": "CRITICAL",
+    "notes": "OSV-confirmed malicious package (MAL-2026-6582). Reported by: amazon-inspector, Amazon Inspector. Review affected versions before promoting to AS-008."
+  }
+]


### PR DESCRIPTION
**MCP/AI-relevant** OSV-confirmed malicious packages from ecosystem feeds for the last 24 hours.

These entries are **OSV `MAL-` records** — confirmed malicious packages sourced from
OpenSSF malicious-packages, Amazon Inspector, GitHub Advisory, and similar reporters.
They are **not** ordinary CVEs.

A **MCP/AI relevance filter** has been applied: only packages whose name or description
contains MCP/AI-tooling domain markers (`mcp`, `openai`, `anthropic`, `claude`,
`langchain`, `tiktoken`, `ollama`, etc.) are included here. Unrelated malicious packages
(crypto typosquats, banking malware, etc.) are excluded — they are already covered by
AS-004 real-time OSV lookup and do not belong in the AS-008 MCP-focused blacklist.

This is a **review-only** PR. It intentionally does not modify:

- `pkg/analyzer/data/blacklist.json`
- `pkg/analyzer/data/npm_iocs.json`

Review each entry:
- Confirm the package is genuinely MCP/AI-tooling related.
- Check the affected version range: is it exact and narrow enough?
- Is this package high-value enough to add to the AS-008 offline blacklist, or is
  AS-004 (real-time OSV lookup) sufficient coverage?
- Review the `notes` field for source attribution (e.g. amazon-inspector, ossf-package-analysis).

To promote a confirmed entry into AS-008:

```bash
go run ./cmd/tooltrust-ioc-promote <reviewed-candidate-json>
```

Close this PR after triage unless it is intentionally converted into a curated data update.