### PR TITLE
ci: bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Download modules
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Run golangci-lint
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Build CLI (tooltrust-scanner)
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Build tooltrust-scanner binary
@@ -226,7 +226,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Verify go install (README primary method)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - run: go test -race -count=1 ./...
 
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Set version from tag

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install govulncheck
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Run gosec
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Build tooltrust-scanner

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/AgentSafe-AI/tooltrust-scanner
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51


### PR DESCRIPTION
## Summary
- bump GitHub Actions Go setup from 1.26.4 to 1.26.5 across CI, security, and release workflows
- update go.mod toolchain to go1.26.5

## Why
The Security workflow failed in govulncheck because Go 1.26.4 includes GO-2026-5856 in crypto/tls. govulncheck reports it fixed in Go 1.26.5.

## Verification
- rg -n "1\.26\.4|1\.26\.5" go.mod .github/workflows
- ruby -e 'require "yaml"; [".github/workflows/ci.yml", ".github/workflows/security.yml", ".github/workflows/release.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'
- go test ./...